### PR TITLE
On the fly index

### DIFF
--- a/src/components/GlobeControls.vue
+++ b/src/components/GlobeControls.vue
@@ -131,6 +131,8 @@ const setDefaultColormap = () => {
     colormap.value = defaultColormap.name;
   }
 };
+
+publish();  // ensure initial settings are published
 </script>
 
 <template>


### PR DESCRIPTION
This PR adds on-the fly index generation:

E.g.: as in https://on-the-fly-index.gridlook.pages.dev/#https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_7.zarr, an json-index is now generated on-the fly when a zarr store is passed insted of an index.json file.

This currently only solves parts of #13, as there's currently no way to specify default colormaps and ranges. But I'd probably leave that for another PR.