### PR TITLE
Include standard_name

### DIFF
--- a/src/components/GlobeControls.vue
+++ b/src/components/GlobeControls.vue
@@ -169,7 +169,7 @@ publish();  // ensure initial settings are published
             :key="varname"
             :value="varname"
           >
-            {{ varname }}
+            {{ varname }} {{ modelInfo.vars[varname].attrs.standard_name ? ' - ' + modelInfo.vars[varname].attrs.standard_name : '' }}
           </option>
         </select>
       </div>

--- a/src/components/GlobeControls.vue
+++ b/src/components/GlobeControls.vue
@@ -169,7 +169,8 @@ publish();  // ensure initial settings are published
             :key="varname"
             :value="varname"
           >
-            {{ varname }} {{ modelInfo.vars[varname].attrs.standard_name ? ' - ' + modelInfo.vars[varname].attrs.standard_name : '' }}
+            {{ varname }} <span v-if=" modelInfo.vars[varname]?.attrs?.standard_name">- 
+              {{ modelInfo.vars[varname].attrs.standard_name }}</span>
           </option>
         </select>
       </div>

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -126,6 +126,9 @@ async function indexFromZarr(src: string) {
           [varname]: {
             store: src,
             dataset: "",
+            attrs: {
+              ...variable.attrs
+            },
           }
         };
       } else {


### PR DESCRIPTION
With the code changes, when available, one can see the standard name (proposed by the CF conventions) along with the variable names as well.  