### PR TITLE
CRS detection: allow differently named crs variables

### DIFF
--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -207,6 +207,20 @@ const toggleRotate = () => {
   }
 };
 
+async function findCRSVar(root: zarr.FetchStore, varname: string) {
+  const datavar = await zarr.open(root.resolve(varname), {
+    kind: "array",
+  });
+  if ( datavar.attrs?.grid_mapping ) {
+    return String(datavar.attrs.grid_mapping).split(":")[0];
+  }
+  const group = await zarr.open(root, {kind: "group"});
+  if ( group.attrs?.grid_mapping ) {
+    return String(group.attrs.grid_mapping).split(":")[0];
+  }
+  return "crs";
+}
+
 async function getGridType() {
   // FIXME: This is a clumsy hack to distinguish between different
   // grid types.
@@ -232,17 +246,20 @@ async function getGridType() {
     } catch (e) {
       /* empty */
     }
-    const root = zarr.root(new zarr.FetchStore(datasource.store));
-    const datavar = await zarr.open(
-      root.resolve(datasource.dataset + `/${varnameSelector.value}`),
-      {
-        kind: "array",
-      }
+    const root = zarr.root(
+      new zarr.FetchStore(datasource.store + datasource.dataset)
     );
+    const datavar = await zarr.open(root.resolve(varnameSelector.value), {
+      kind: "array",
+    });
+
     try {
-      const crs = await zarr.open(root.resolve(datasource.dataset + `/crs`), {
-        kind: "array",
-      });
+      const crs = await zarr.open(
+        root.resolve(await findCRSVar(root, varnameSelector.value)),
+        {
+          kind: "array",
+        }
+      );
       console.log("CRS ATTRS", crs.attrs);
       if (crs.attrs["grid_mapping_name"] === "healpix") {
         return GRID_TYPES.HEALPIX;


### PR DESCRIPTION
Using this change, it's possible to access NICAM data, e.g. [on preview deployment](https://844ddd00.gridlook.pages.dev/#https://nowake.nicam.jp/files/healpix/NICAM_2d3h_z7.zarr)