### PR TITLE
add azimuthal equidistant projection

### DIFF
--- a/src/components/Globe.vue
+++ b/src/components/Globe.vue
@@ -6,6 +6,7 @@ import {
   makeColormapMaterial,
   availableColormaps,
   calculateColorMapProperties,
+  availableProjections,
 } from "./utils/colormapShaders.ts";
 import { decodeTime } from "./utils/timeHandling.ts";
 
@@ -26,6 +27,7 @@ import { storeToRefs } from "pinia";
 import type {
   TBounds,
   TColorMap,
+  TProjection,
   TSources,
   TVarInfo,
 } from "../types/GlobeTypes.ts";
@@ -38,6 +40,7 @@ const props = defineProps<{
   varbounds?: TBounds;
   colormap?: TColorMap;
   invertColormap?: boolean;
+  projection?: TProjection;
 }>();
 
 const emit = defineEmits<{ varinfo: [TVarInfo] }>();
@@ -109,11 +112,18 @@ watch(
   }
 );
 
+watch(
+  () => props.projection,
+  () => {
+    updateProjection();
+  }
+);
+
 const colormapMaterial = computed(() => {
   if (props.invertColormap) {
-    return makeColormapMaterial(props.colormap, 1.0, -1.0);
+    return makeColormapMaterial(props.colormap, 1.0, -1.0, props.projection);
   } else {
-    return makeColormapMaterial(props.colormap, 0.0, 1.0);
+    return makeColormapMaterial(props.colormap, 0.0, 1.0, props.projection);
   }
 });
 
@@ -182,6 +192,16 @@ function updateColormap() {
   material.uniforms.addOffset.value = addOffset;
   material.uniforms.scaleFactor.value = scaleFactor;
   redraw();
+}
+
+function updateProjection() {
+  if (props.projection) {
+    const myMesh = mainMesh as THREE.Mesh;
+    const material = myMesh.material as THREE.ShaderMaterial;
+    material.uniforms.projection.value =
+      availableProjections[props.projection!];
+    redraw();
+  }
 }
 
 async function getData() {

--- a/src/components/GlobeControls.vue
+++ b/src/components/GlobeControls.vue
@@ -7,9 +7,11 @@ import type {
   TColorMap,
   TModelInfo,
   TBounds,
+  TProjection,
   TVarInfo,
   TSelection,
 } from "../types/GlobeTypes.js";
+import { availableProjections } from "./utils/colormapShaders.ts";
 
 const props = defineProps<{ varinfo?: TVarInfo; modelInfo?: TModelInfo }>();
 
@@ -32,6 +34,7 @@ const defaultBounds: Ref<TBounds> = ref({});
 const userBoundsLow: Ref<number | undefined> = ref(undefined);
 const userBoundsHigh: Ref<number | undefined> = ref(undefined);
 const pickedBounds = ref("auto");
+const projection: Ref<TProjection> = ref("perspective");
 
 const activeBounds = computed(() => {
   if (pickedBounds.value === "auto") {
@@ -119,6 +122,11 @@ watch(
   () => setDefaultColormap()
 );
 
+watch(
+  () => projection.value,
+  () => publish()
+);
+
 function toggleMenu() {
   menuCollapsed.value = !menuCollapsed.value;
 }
@@ -132,6 +140,7 @@ const publish = () => {
     bounds: bounds.value as TBounds,
     colormap: colormap.value,
     invertColormap: invertColormap.value,
+    projection: projection.value,
   });
 };
 
@@ -402,6 +411,19 @@ publish(); // ensure initial settings are published
           <i class="fa-solid fa-rotate mr-1"></i>
           Toggle Rotation
         </button>
+      </div>
+    </div>
+    <div v-if="modelInfo && !isHidden" class="panel-block">
+      <div class="select is-fullwidth">
+        <select v-model="projection">
+          <option
+            v-for="p in Object.keys(availableProjections)"
+            :key="p"
+            :value="p"
+          >
+            {{ p }}
+          </option>
+        </select>
       </div>
     </div>
     <div v-if="modelInfo && !isHidden" class="panel-block">

--- a/src/components/utils/colormapShaders.ts
+++ b/src/components/utils/colormapShaders.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import type { TColorMap } from "../../types/GlobeTypes";
+import type { TColorMap, TProjection } from "../../types/GlobeTypes";
 
 export const availableColormaps = {
   inferno: 0,
@@ -60,6 +60,11 @@ export const availableColormaps = {
   curl: 55,
   diff: 56,
   tarn: 57,
+} as const;
+
+export const availableProjections = {
+  perspective: 0,
+  azimuthal: 1,
 } as const;
 
 const shaders = `
@@ -1031,14 +1036,40 @@ void main() {
     ${distinguishShaders}
 }`;
 
+const PI = 3.14159265359;
+
+const positionVertexShaderPerspective = `
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+`;
+
+const positionVertexShaderAzimuthal = `
+      vec3 pos = mat3(modelViewMatrix) * position;
+      float dist = (${PI} / 2.) - asin(pos.z);
+      pos.xy = normalize(pos.xy) * (dist * .25);
+      pos.z = -10. + pos.z * 0.001;
+      gl_Position = projectionMatrix * vec4(pos, 1.);
+`;
+
+const positionVertexShaderUniforms = `
+uniform int projection;
+`;
+const positionVertexShaderPart = `
+      if (projection == 0) {
+        ${positionVertexShaderPerspective}
+      } else if (projection == 1) {
+        ${positionVertexShaderAzimuthal}
+      }
+`;
+
 const dataOnMeshVertexShader = `
     attribute float data_value;
 
     varying float v_value;
+    ${positionVertexShaderUniforms}
 
     void main() {
       v_value = data_value;
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+      ${positionVertexShaderPart}
     }
     `;
 
@@ -1055,23 +1086,26 @@ const dataOnScreenMeshVertexShader = `
 
 const dataOnTextureVertexShader = `
     varying vec2 vUv;
+    ${positionVertexShaderUniforms}
 
     void main() {
       vUv = uv;
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+      ${positionVertexShaderPart}
     }
     `;
 
 export function makeColormapMaterial(
   colormap: TColorMap = "turbo",
   addOffset: 1.0 | 0.0 = 0.0,
-  scaleFactor: -1.0 | 1.0 = 1.0
+  scaleFactor: -1.0 | 1.0 = 1.0,
+  projection: TProjection = "perspective"
 ) {
   const material = new THREE.ShaderMaterial({
     uniforms: {
       addOffset: { value: addOffset },
       scaleFactor: { value: scaleFactor },
       colormap: { value: availableColormaps[colormap] },
+      projection: { value: availableProjections[projection] },
     },
 
     vertexShader: dataOnMeshVertexShader,
@@ -1102,7 +1136,8 @@ export function makeTextureMaterial(
   texture: THREE.Texture,
   colormap: TColorMap = "turbo",
   addOffset: number,
-  scaleFactor: number
+  scaleFactor: number,
+  projection: TProjection = "perspective"
 ) {
   const material = new THREE.ShaderMaterial({
     uniforms: {
@@ -1110,6 +1145,7 @@ export function makeTextureMaterial(
       scaleFactor: { value: scaleFactor },
       colormap: { value: availableColormaps[colormap] },
       data: { value: texture },
+      projection: { value: availableProjections[projection] },
     },
 
     vertexShader: dataOnTextureVertexShader,

--- a/src/components/utils/colormapShaders.ts
+++ b/src/components/utils/colormapShaders.ts
@@ -1045,7 +1045,7 @@ const positionVertexShaderPerspective = `
 const positionVertexShaderAzimuthal = `
       vec3 pos = mat3(modelViewMatrix) * position;
       float dist = (${PI} / 2.) - asin(pos.z);
-      pos.xy = normalize(pos.xy) * (dist * .25);
+      pos.xy = normalize(pos.xy) * (dist * .39);
       pos.z = -10. + pos.z * 0.001;
       gl_Position = projectionMatrix * vec4(pos, 1.);
 `;

--- a/src/types/GlobeTypes.ts
+++ b/src/types/GlobeTypes.ts
@@ -1,10 +1,14 @@
 import type { Dayjs } from "dayjs";
-import type { availableColormaps } from "../components/utils/colormapShaders.ts";
+import type {
+  availableColormaps,
+  availableProjections,
+} from "../components/utils/colormapShaders.ts";
 import * as zarr from "zarrita";
 
 export type EmptyObj = Record<PropertyKey, never>;
 
 export type TColorMap = keyof typeof availableColormaps;
+export type TProjection = keyof typeof availableProjections;
 
 export type TBounds = EmptyObj | { low: number; high: number };
 
@@ -12,6 +16,7 @@ export type TSelection = {
   colormap: TColorMap;
   invertColormap: boolean;
   bounds: TBounds;
+  projection: TProjection;
 };
 
 export type TVarInfo = {

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -360,6 +360,7 @@ onMounted(async () => {
       :invert-colormap="selection.invertColormap"
       :varbounds="selection.bounds"
       :is-rotated="gridType === GRID_TYPES.REGULAR_ROTATED"
+      :projection="selection.projection"
       @varinfo="updateVarinfo"
     />
     <div v-if="isLoading || loading" class="top-right-loader loader" />


### PR DESCRIPTION
This PR adds a way to select between different projections. In addition to the current perspective projection, [azimuthal equidistant projection](https://en.wikipedia.org/wiki/Azimuthal_equidistant_projection) is implemented. This is the projection used by the [SPHERE](https://sphere.blue/en.html) spherical display. Similar projections might be applicable to other spherical displays, and we might want to use this method to explore other (map-) projections (e.g. plate-carree, mollweide etc...).

This PR might have some interactions with #33, as the projection argument has to be passed along. I'd be happy adapting this PR after #33 is merged, or we can do it the other way around 🤷 