### PR TITLE
Limited-area healpix

### DIFF
--- a/src/components/utils/zarrUtils.ts
+++ b/src/components/utils/zarrUtils.ts
@@ -1,4 +1,18 @@
+import type { TSources } from "@/types/GlobeTypes";
 import * as zarr from "zarrita";
+
+export function getDataSourceStore(datasources: TSources, varname: string) {
+  const datasource = datasources.levels[0].datasources[varname];
+  return zarr.root(
+    new zarr.FetchStore(
+      (datasource.store.endsWith("/")
+        ? datasource.store.slice(0, -1)
+        : datasource.store) +
+        "/" +
+        datasource.dataset
+    )
+  );
+}
 
 export async function findCRSVar(root: zarr.FetchStore, varname: string) {
   const datavar = await zarr.open(root.resolve(varname), {

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -16,7 +16,8 @@ import { storeToRefs } from "pinia";
 import { getErrorMessage } from "../components/utils/errorHandling";
 import StoreUrlListener from "../components/store/storeUrlListener.vue";
 import { useUrlParameterStore } from "../components/store/paramStore";
-import { findCRSVar } from "../components/utils/zarrUtils";
+import { findCRSVar, getDataSourceStore } from "../components/utils/zarrUtils";
+
 const props = defineProps<{ src: string }>();
 
 const GRID_TYPES = {
@@ -259,8 +260,6 @@ async function getGridType() {
   if (!sourceValid.value) {
     return GRID_TYPES.ERROR;
   }
-  const datasource =
-    datasources.value!.levels[0].datasources[varnameSelector.value];
   try {
     try {
       // CHECK IF TRIANGULAR
@@ -277,15 +276,8 @@ async function getGridType() {
     } catch (e) {
       /* empty */
     }
-    const root = zarr.root(
-      new zarr.FetchStore(
-        (datasource.store.endsWith("/")
-          ? datasource.store.slice(0, -1)
-          : datasource.store) +
-          "/" +
-          datasource.dataset
-      )
-    );
+
+    const root = getDataSourceStore(datasources.value!, varnameSelector.value);
 
     const datavar = await zarr.open(root.resolve(varnameSelector.value), {
       kind: "array",


### PR DESCRIPTION
First implementation of limited area-healpix. I tried to re-use as much old code as possible so that we still have only one GlobeHealpix-File.

Currently there are a few wonky assumptions, since I had only one dataset to play with:

- `nside` is an attribute of `crs` and stored in `healpix_nside`
- if there is a `cell`-dimension, then it's limited-area

Feel free to suggest better ways to find all the necessary information. It worked only with the stuff I had available.

I tried it out with the following dataset:
https://eerie.cloud.dkrz.de/datasets/orcestra.ICON-LAM.s2024-08-10_2d_PT10M_12/kerchunk

Here is a screenshot:

<img width="2218" height="1073" alt="Screenshot 2025-11-04 at 11-45-21 Gridlook" src="https://github.com/user-attachments/assets/39b772f6-7fb7-4098-8ff4-0f84cbf4ab4a" />

