### PR TITLE
error logging: write errors to console, including traceback

### DIFF
--- a/src/components/Globe.vue
+++ b/src/components/Globe.vue
@@ -24,8 +24,7 @@ import {
 import { useGlobeControlStore } from "./store/store.js";
 import { storeToRefs } from "pinia";
 import type { TSources } from "../types/GlobeTypes.ts";
-import { useToast } from "primevue/usetoast";
-import { getErrorMessage } from "./utils/errorHandling.ts";
+import { useLog } from "./utils/logging";
 import { useSharedGlobeLogic } from "./sharedGlobe.ts";
 
 const props = defineProps<{
@@ -33,7 +32,7 @@ const props = defineProps<{
 }>();
 
 const store = useGlobeControlStore();
-const toast = useToast();
+const { logError } = useLog();
 const {
   timeIndexSlider,
   varnameSelector,
@@ -145,10 +144,7 @@ async function fetchGrid() {
     myMesh.geometry.computeBoundingSphere();
     redraw();
   } catch (error) {
-    toast.add({
-      detail: `Could not fetch grid: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch grid");
   }
 }
 
@@ -221,10 +217,7 @@ async function getData() {
       await getData();
     }
   } catch (error) {
-    toast.add({
-      detail: `Couldn't fetch data: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch data");
     updatingData.value = false;
   } finally {
     store.stopLoading();

--- a/src/components/GlobeHealpix.vue
+++ b/src/components/GlobeHealpix.vue
@@ -15,7 +15,7 @@ import { useGlobeControlStore } from "./store/store.js";
 import { storeToRefs } from "pinia";
 import type { TSources, TVarInfo } from "../types/GlobeTypes.ts";
 import { useToast } from "primevue/usetoast";
-import { getErrorMessage } from "./utils/errorHandling.ts";
+import { useLog } from "./utils/logging";
 import { useSharedGlobeLogic } from "./sharedGlobe.ts";
 import { findCRSVar, getDataSourceStore } from "./utils/zarrUtils.ts";
 
@@ -25,6 +25,7 @@ const props = defineProps<{
 
 const store = useGlobeControlStore();
 const toast = useToast();
+const { logError } = useLog();
 const {
   timeIndexSlider,
   varnameSelector,
@@ -152,10 +153,7 @@ async function fetchGrid() {
     }
     redraw();
   } catch (error) {
-    toast.add({
-      detail: `Could not fetch grid: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch grid");
   }
 }
 
@@ -417,10 +415,7 @@ async function getData() {
       await getData(); // Restart update if another one queued
     }
   } catch (error) {
-    toast.add({
-      detail: `Couldn't fetch data: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch data");
     updatingData.value = false;
   } finally {
     store.stopLoading();

--- a/src/components/GlobeIrregular.vue
+++ b/src/components/GlobeIrregular.vue
@@ -23,8 +23,7 @@ import {
 import { useGlobeControlStore } from "./store/store.js";
 import { storeToRefs } from "pinia";
 import type { TSources } from "../types/GlobeTypes.ts";
-import { useToast } from "primevue/usetoast";
-import { getErrorMessage } from "./utils/errorHandling.ts";
+import { useLog } from "./utils/logging";
 import { useSharedGlobeLogic } from "./sharedGlobe.ts";
 
 const props = defineProps<{
@@ -32,7 +31,7 @@ const props = defineProps<{
 }>();
 
 const store = useGlobeControlStore();
-const toast = useToast();
+const { logError } = useLog();
 const {
   timeIndexSlider,
   colormap,
@@ -301,10 +300,7 @@ async function getData() {
       await getData();
     }
   } catch (error) {
-    toast.add({
-      detail: `Couldn't fetch data: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch data");
     updatingData.value = false;
   } finally {
     store.stopLoading();

--- a/src/components/GlobeRegular.vue
+++ b/src/components/GlobeRegular.vue
@@ -15,7 +15,7 @@ import { useGlobeControlStore } from "./store/store.js";
 import { storeToRefs } from "pinia";
 import type { TSources } from "../types/GlobeTypes.ts";
 import { useToast } from "primevue/usetoast";
-import { getErrorMessage } from "./utils/errorHandling.ts";
+import { useLog } from "./utils/logging";
 import { useSharedGlobeLogic } from "./sharedGlobe.ts";
 
 const props = defineProps<{
@@ -25,6 +25,7 @@ const props = defineProps<{
 
 const store = useGlobeControlStore();
 const toast = useToast();
+const { logError } = useLog();
 const {
   timeIndexSlider,
   colormap,
@@ -348,10 +349,7 @@ async function makeGeometry() {
     mainMesh!.geometry = geometry;
     redraw();
   } catch (error) {
-    toast.add({
-      detail: `Could not fetch grid: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch grid");
   }
 }
 
@@ -466,10 +464,7 @@ async function getData() {
       await getData();
     }
   } catch (error) {
-    toast.add({
-      detail: `Couldn't fetch data: ${getErrorMessage(error)}`,
-      life: 3000,
-    });
+    logError(error, "Could not fetch data");
     updatingData.value = false;
   } finally {
     store.stopLoading();

--- a/src/components/sharedGlobe.ts
+++ b/src/components/sharedGlobe.ts
@@ -13,10 +13,9 @@ import { geojson2geometry } from "./utils/geojson.ts";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { handleKeyDown } from "./utils/OrbitControlsAddOn.ts";
-import { useToast } from "primevue/usetoast";
+import { useLog } from "./utils/logging";
 import * as zarr from "zarrita";
 import type { TSources } from "@/types/GlobeTypes.ts";
-import { getErrorMessage } from "./utils/errorHandling.ts";
 import { useUrlParameterStore } from "./store/paramStore.ts";
 import { getLandSeaMask, loadJSON } from "./utils/landSeaMask.ts";
 import debounce from "lodash.debounce";
@@ -32,7 +31,7 @@ export function useSharedGlobeLogic(
   const urlParameterStore = useUrlParameterStore();
   const { paramCameraState } = storeToRefs(urlParameterStore);
 
-  const toast = useToast();
+  const { logError } = useLog();
   const datavars: ShallowRef<
     Record<string, zarr.Array<zarr.DataType, zarr.FetchStore>>
   > = shallowRef({});
@@ -333,10 +332,10 @@ export function useSharedGlobeLogic(
         );
         datavars.value[myVarname] = datavar;
       } catch (error) {
-        toast.add({
-          detail: `Couldn't fetch variable ${myVarname} from store: ${myDatasource.store} and dataset: ${myDatasource.dataset}: ${getErrorMessage(error)}`,
-          life: 3000,
-        });
+        logError(
+          error,
+          `Couldn't fetch variable ${myVarname} from store: ${myDatasource.store} and dataset: ${myDatasource.dataset}`
+        );
         return undefined;
       }
     }

--- a/src/components/utils/errorHandling.ts
+++ b/src/components/utils/errorHandling.ts
@@ -3,11 +3,13 @@
 // This is a workaround to get clean error messages
 // Credits:
 // https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript
-type ErrorWithMessage = {
+
+type NormalizedError = {
   message: string;
+  stack?: unknown;
 };
 
-function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+function isNormalizedError(error: unknown): error is NormalizedError {
   return (
     typeof error === "object" &&
     error !== null &&
@@ -16,8 +18,8 @@ function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
   );
 }
 
-function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-  if (isErrorWithMessage(maybeError)) return maybeError;
+export function toNormalizedError(maybeError: unknown): NormalizedError {
+  if (isNormalizedError(maybeError)) return maybeError;
 
   try {
     return new Error(JSON.stringify(maybeError));
@@ -29,5 +31,5 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 }
 
 export function getErrorMessage(error: unknown) {
-  return toErrorWithMessage(error).message;
+  return toNormalizedError(error).message;
 }

--- a/src/components/utils/logging.ts
+++ b/src/components/utils/logging.ts
@@ -1,0 +1,18 @@
+import { useToast } from "primevue/usetoast";
+import { toNormalizedError } from "./errorHandling";
+
+export function useLog() {
+  const toast = useToast();
+
+  function logError(maybeError: unknown, context?: string) {
+    const error = toNormalizedError(maybeError);
+    console.error(context, error, error?.stack);
+    const prefix = context !== undefined ? `${context}: ` : "";
+    toast.add({
+      detail: `${prefix}${error.message}`,
+      life: 3000,
+    });
+  }
+
+  return { logError };
+}

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -11,9 +11,8 @@ import { ref, computed, watch, onMounted, type Ref } from "vue";
 import type { TColorMap, TSources } from "../types/GlobeTypes";
 import { useGlobeControlStore } from "../components/store/store";
 import Toast from "primevue/toast";
-import { useToast } from "primevue/usetoast";
+import { useLog } from "../components/utils/logging";
 import { storeToRefs } from "pinia";
-import { getErrorMessage } from "../components/utils/errorHandling";
 import StoreUrlListener from "../components/store/storeUrlListener.vue";
 import { useUrlParameterStore } from "../components/store/paramStore";
 import { findCRSVar, getDataSourceStore } from "../components/utils/zarrUtils";
@@ -32,7 +31,7 @@ const GRID_TYPES = {
 
 type T_GRID_TYPES = (typeof GRID_TYPES)[keyof typeof GRID_TYPES];
 
-const toast = useToast();
+const { logError } = useLog();
 const store = useGlobeControlStore();
 const { varnameSelector, loading, colormap, invertColormap } =
   storeToRefs(store);
@@ -227,12 +226,7 @@ const updateSrc = async () => {
     }
   }
   if (!sourceValid.value && lastError) {
-    toast.add({
-      severity: "error",
-      summary: "Error",
-      detail: `Failed to fetch data: ${lastError.message}`,
-      life: 3000,
-    });
+    logError(lastError, "Failed to fetch data");
   }
 };
 
@@ -325,11 +319,7 @@ async function getGridType() {
     }
     return GRID_TYPES.GAUSSIAN;
   } catch (error) {
-    toast.add({
-      detail: `${getErrorMessage(error)}`,
-      life: 3000,
-    });
-
+    logError(error, "Could not determine grid type");
     return GRID_TYPES.ERROR;
   }
 }


### PR DESCRIPTION
This PR moves common error logging functionality into a separate logging module, reducing some repeated code. Within this common logging function, the current behaviour (showing the error in a `toast`) is retained, but in addition, the error is also logged to the console, including the stacktrace of the error. This can sometimes facilitate debugging issues with unreadable datasets.