### PR TITLE
Time handling

### DIFF
--- a/src/lib/data/timeHandling.ts
+++ b/src/lib/data/timeHandling.ts
@@ -13,10 +13,7 @@ export function decodeTime(value: number, attrs: zarr.Attributes) {
   }
   let interval = regExMatch[1];
   let refdate = regExMatch[2];
-  if (
-    refdate.indexOf(" ") !== refdate.lastIndexOf(" ") &&
-    refdate.includes(" ")
-  ) {
+  if (refdate.indexOf(" ") !== refdate.lastIndexOf(" ")) {
     // if there are multiple spaces, it's likely because the timezone is included
     // remove the timezone for dayjs parsing
     // The format then is something like "2001-01-01 00:00:00.0 0:00"


### PR DESCRIPTION
This fixes a "bug" for certain data I saw in FREVA where the timestamp had a format we didn't encounter before `2001-01-01 00:00:00.0 0:00` which couldn't be parsed by dayjs. `decodeTime` catches such cases now and trims everything after the last space in order to make the format readable for dayjs.

The data can be found here:
https://freva.dkrz.de/databrowser/?model=radklim&start=0