### PR TITLE
Catalog added

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can view any CORS-enabled, public Zarr dataset with GridLook:
 https://gridlook.pages.dev/#<ZARR_URI>
 ```
 
-Gridlook can also load catalog JSON files that list multiple datasets. The catalog format and deployment options are documented in [docs/catalogs.md](/home/afast/workspace/gridlook/docs/catalogs.md).
+Gridlook can also load catalog JSON files that list multiple datasets. The catalog format and deployment options are documented in [docs/catalogs.md](docs/catalogs.md).
 
 ## Project Setup
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can view any CORS-enabled, public Zarr dataset with GridLook:
 https://gridlook.pages.dev/#<ZARR_URI>
 ```
 
+Gridlook can also load catalog JSON files that list multiple datasets. The catalog format and deployment options are documented in [docs/catalogs.md](/home/afast/workspace/gridlook/docs/catalogs.md).
+
 ## Project Setup
 
 This project uses [Node.js](https://nodejs.org/en) and [vue.js](https://vuejs.org/)

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -1,0 +1,95 @@
+# Providing Catalogs to Gridlook
+
+Gridlook can load either a dataset URL directly or a catalog JSON document that lists multiple datasets.
+
+When a user enters a catalog URL in the "Open dataset" dialog, Gridlook fetches the JSON, shows the catalog entries, and lets the user open one of the listed datasets.
+
+## Catalog Format
+
+A Gridlook catalog is a JSON document with:
+
+- `type`: must be `"gridlook_catalog"`
+- `title`: optional catalog title shown in the UI
+- `datasets`: array of dataset entries
+
+Each dataset entry currently supports:
+
+- `url`: required dataset URL
+- `title`: optional display name
+- `tag`: optional short label shown in the catalog list
+- `description`: optional longer text used in the catalog list and search
+
+Example:
+
+```json
+{
+  "type": "gridlook_catalog",
+  "title": "My Gridlook Catalog",
+  "datasets": [
+    {
+      "title": "ICON Daily Mean",
+      "url": "https://example.org/icon/daily_mean.zarr",
+      "tag": "healpix",
+      "description": "Daily mean atmosphere output on the native grid."
+    },
+    {
+      "title": "AWI Ocean",
+      "url": "https://example.org/awi/ocean.zarr",
+      "tag": "irregular"
+    }
+  ]
+}
+```
+
+## Hosting Requirements
+
+Gridlook fetches the catalog from the browser, so the catalog URL must be:
+
+- publicly reachable from the client
+- served as valid JSON
+- CORS-enabled when hosted on another origin
+
+The same browser-side access rules also apply to the dataset URLs listed inside the catalog.
+
+## Ways to Provide a Catalog
+
+### 1. Ship a Catalog with the App
+
+Files in [`public/`](public) are served as static assets by Vite.
+
+For example, if you add:
+
+`public/static/my-catalog.json`
+
+it will be available at:
+
+`/static/my-catalog.json`
+
+The current default catalog in this repository is [`public/static/catalog.json`](/public/static/catalog.json).
+
+If you want your deployment to open a different default catalog on first load, update `DEFAULT_CATALOG` in [`src/views/HashGlobeView.vue`](/src/views/HashGlobeView.vue).
+
+### 2. Host a Catalog Externally
+
+You can also host the catalog anywhere else and paste its URL into the "Open dataset" dialog, for example:
+
+`https://example.org/gridlook/catalog.json`
+
+Gridlook will detect that the URL is a catalog, load it, and show its dataset entries in the dialog.
+
+## Sharing Links with a Catalog
+
+When a dataset is opened from a catalog, Gridlook keeps the catalog URL in the hash using the `catalog` parameter. This allows shared links to reopen the same dataset while preserving the catalog context.
+
+Example:
+
+```text
+#https://example.org/icon/daily_mean.zarr::catalog=https%3A%2F%2Fexample.org%2Fgridlook%2Fcatalog.json
+```
+
+## Notes
+
+- `tag` is only used for display and sorting in the catalog panel.
+- `description` is shown in the catalog panel and is also included in search.
+- Use dataset URLs that Gridlook can already open directly.
+- Absolute HTTPS URLs are the safest choice for catalog entries.

--- a/public/static/catalog.json
+++ b/public/static/catalog.json
@@ -1,0 +1,41 @@
+{
+  "type": "gridlook_catalog",
+  "title": "Default Catalog",
+  "datasets": [
+    {
+      "title": "80km historical MPI-ESM1-2-HR Amon tas",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/Amon/tas/gn/v20190710/",
+      "tag": "regular"
+    },
+    {
+      "title": "250km PMIP IPSL-CM6A-LR Amon tas",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/PMIP/IPSL/IPSL-CM6A-LR/midHolocene/r1i1p1f3/Amon/tas/gr/v20180926/",
+      "tag": "regular"
+    },
+    {
+      "title": "50km HighResMIP HadGEM3 highres-future Amon tas",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/HighResMIP/MOHC/HadGEM3-GC31-HM/highresSST-present/r1i1p1f1/Amon/tas/gn/v20170831/",
+      "tag": "regular"
+    },
+    {
+      "title": "50km tripolar historical NOAA GFDL-ESM4 Omon tos",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r2i1p1f1/Omon/tos/gn/v20180701/",
+      "tag": "curvilinear"
+    },
+    {
+      "title": "25km historical AWI-CM-1-1-MR",
+      "url": "https://cmip6-pds.s3.amazonaws.com/CMIP6/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/Oday/tos/gn/v20181218/",
+      "tag": "irregular"
+    },
+    {
+      "title": "WCRP Hackathon - P1D_mean_z7_atm",
+      "url": "https://s3.eu-dkrz-1.dkrz.cloud/wrcp-hackathon/data/ICON/d3hp003.zarr/P1D_mean_z7_atm",
+      "tag": "healpix"
+    },
+    {
+      "title": "dpp0066 - 2d_ml @ R02B06",
+      "url": "https://gridlook.pages.dev/static/index_mr_dpp0066.json",
+      "tag": "triangular"
+    }
+  ]
+}

--- a/src/store/paramStore.ts
+++ b/src/store/paramStore.ts
@@ -28,6 +28,7 @@ export const useUrlParameterStore = defineStore("urlParams", {
       paramProjectionCenterLat: undefined as string | undefined,
       paramProjectionCenterLon: undefined as string | undefined,
       paramGridType: undefined as string | undefined,
+      paramCatalog: undefined as string | undefined,
     };
   },
   actions: {
@@ -67,4 +68,5 @@ export const STORE_PARAM_MAPPING = {
   projectionCenterLat: "paramProjectionCenterLat",
   projectionCenterLon: "paramProjectionCenterLon",
   gridtype: "paramGridType",
+  catalog: "paramCatalog",
 } as const;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/projection/projectionUtils";
 import type { TColorMap } from "@/lib/shaders/colormapShaders";
 import type { TVarInfo, TBounds } from "@/lib/types/GlobeTypes";
+import type { TCatalog } from "@/utils/catalog";
 
 export const UPDATE_MODE = {
   INITIAL_LOAD: "initialLoad",
@@ -67,6 +68,8 @@ export const useGlobeControlStore = defineStore("globeControl", {
       isRotating: false,
       hoverEnabled: false,
       hoveredGridPoint: undefined as THoveredGridPoint | undefined,
+      catalogUrl: undefined as string | undefined,
+      catalogData: undefined as TCatalog | undefined,
     };
   },
   actions: {

--- a/src/ui/overlays/controls/CatalogPanel.vue
+++ b/src/ui/overlays/controls/CatalogPanel.vue
@@ -58,8 +58,8 @@ function select(entry: TCatalogEntry) {
     <h2 class="catalog-title">
       {{ title ?? "Dataset Catalog" }}
     </h2>
-    <div class="is-flex-direction-column my-3" style="gap: 0.5rem">
-      <div class="control has-icons-left mb-2" style="width: 100%">
+    <div class="is-flex-direction-column my-3 w-100">
+      <div class="control has-icons-left mb-2">
         <input
           v-model="searchQuery"
           class="input is-small"
@@ -71,8 +71,7 @@ function select(entry: TCatalogEntry) {
         </span>
       </div>
       <div
-        class="is-flex is-align-items-center is-justify-content-space-between"
-        style="width: 100%"
+        class="is-flex is-align-items-center is-justify-content-space-between w-100"
       >
         <span class="is-size-7 has-text-grey">
           {{ filteredAndSortedDatasets.length }} /
@@ -148,7 +147,6 @@ function select(entry: TCatalogEntry) {
 .catalog-panel {
   margin-top: 1rem;
   max-height: 400px;
-  // border-top: 1px solid var(--bulma-border);
 }
 
 .catalog-entries {
@@ -170,6 +168,9 @@ function select(entry: TCatalogEntry) {
     background-color: var(--bulma-link-light) !important;
   }
   border-bottom: 1px solid var(--bulma-border) !important;
+  &:last-child {
+    border-bottom: none !important;
+  }
 }
 
 .catalog-entry-content {

--- a/src/ui/overlays/controls/CatalogPanel.vue
+++ b/src/ui/overlays/controls/CatalogPanel.vue
@@ -20,20 +20,20 @@ const sortKey = ref<SortKey>("default");
 const filteredAndSortedDatasets = computed(() => {
   const q = searchQuery.value.trim().toLowerCase();
 
-  if (!q) {
-    return props.datasets;
+  let list = [...props.datasets];
+  if (q) {
+    list = props.datasets.filter((entry) => {
+      const haystack = [
+        entry.title ?? "",
+        entry.url,
+        entry.tag ?? "",
+        entry.description ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
   }
-  let list = props.datasets.filter((entry) => {
-    const haystack = [
-      entry.title ?? "",
-      entry.url,
-      entry.tag ?? "",
-      entry.description ?? "",
-    ]
-      .join(" ")
-      .toLowerCase();
-    return haystack.includes(q);
-  });
 
   if (sortKey.value === "title") {
     list.sort((a, b) => (a.title ?? a.url).localeCompare(b.title ?? b.url));
@@ -101,11 +101,12 @@ function select(entry: TCatalogEntry) {
       >
         No datasets match your search.
       </p>
-      <a
+      <button
         v-for="(entry, i) in filteredAndSortedDatasets"
         :key="entry.url + '-' + i"
         class="catalog-entry panel-block"
-        @click.prevent="select(entry)"
+        type="button"
+        @click="select(entry)"
       >
         <div class="catalog-entry-content">
           <div class="catalog-entry-header">
@@ -132,7 +133,7 @@ function select(entry: TCatalogEntry) {
             {{ entry.url }}
           </p>
         </div>
-      </a>
+      </button>
     </div>
   </nav>
 </template>
@@ -158,6 +159,13 @@ function select(entry: TCatalogEntry) {
 
 .catalog-entry {
   display: block !important;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
   &:hover {
     background-color: var(--bulma-link-light) !important;
   }

--- a/src/ui/overlays/controls/CatalogPanel.vue
+++ b/src/ui/overlays/controls/CatalogPanel.vue
@@ -1,0 +1,206 @@
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+
+import type { TCatalogEntry } from "@/utils/catalog";
+
+const props = defineProps<{
+  title?: string;
+  datasets: TCatalogEntry[];
+}>();
+
+const emit = defineEmits<{
+  select: [entry: TCatalogEntry];
+}>();
+
+const searchQuery = ref("");
+
+type SortKey = "default" | "title" | "tag";
+const sortKey = ref<SortKey>("default");
+
+const filteredAndSortedDatasets = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+
+  if (!q) {
+    return props.datasets;
+  }
+  let list = props.datasets.filter((entry) => {
+    const haystack = [
+      entry.title ?? "",
+      entry.url,
+      entry.tag ?? "",
+      entry.description ?? "",
+    ]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+
+  if (sortKey.value === "title") {
+    list.sort((a, b) => (a.title ?? a.url).localeCompare(b.title ?? b.url));
+  } else if (sortKey.value === "tag") {
+    list.sort((a, b) => (a.tag ?? "").localeCompare(b.tag ?? ""));
+  }
+
+  return list;
+});
+
+function displayTitle(entry: TCatalogEntry): string {
+  return entry.title ?? entry.url;
+}
+
+function select(entry: TCatalogEntry) {
+  emit("select", entry);
+}
+</script>
+
+<template>
+  <nav class="catalog-panel mt-4 pt-2">
+    <h2 class="catalog-title">
+      {{ title ?? "Dataset Catalog" }}
+    </h2>
+    <div class="is-flex-direction-column my-3" style="gap: 0.5rem">
+      <div class="control has-icons-left mb-2" style="width: 100%">
+        <input
+          v-model="searchQuery"
+          class="input is-small"
+          type="text"
+          placeholder="Search datasets…"
+        />
+        <span class="icon is-left is-small">
+          <i class="fa-solid fa-magnifying-glass"></i>
+        </span>
+      </div>
+      <div
+        class="is-flex is-align-items-center is-justify-content-space-between"
+        style="width: 100%"
+      >
+        <span class="is-size-7 has-text-grey">
+          {{ filteredAndSortedDatasets.length }} /
+          {{ datasets.length }}
+          dataset{{ datasets.length !== 1 ? "s" : "" }}
+        </span>
+        <div class="field is-grouped is-align-items-center mb-0">
+          <label class="label is-small mr-2 mb-0">Sort</label>
+          <div class="control">
+            <div class="select is-small">
+              <select v-model="sortKey">
+                <option value="default">Default</option>
+                <option value="title">Title</option>
+                <option value="tag">Tag</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="catalog-entries">
+      <p
+        v-if="filteredAndSortedDatasets.length === 0"
+        class="has-text-grey is-size-7"
+      >
+        No datasets match your search.
+      </p>
+      <a
+        v-for="(entry, i) in filteredAndSortedDatasets"
+        :key="entry.url + '-' + i"
+        class="catalog-entry panel-block"
+        @click.prevent="select(entry)"
+      >
+        <div class="catalog-entry-content">
+          <div class="catalog-entry-header">
+            <div class="catalog-entry-main">
+              <span class="icon is-small has-text-link">
+                <i class="fa-solid fa-database"></i>
+              </span>
+              <strong class="catalog-entry-title" :title="displayTitle(entry)">
+                {{ displayTitle(entry) }}
+              </strong>
+            </div>
+            <span v-if="entry.tag" class="tag is-link is-light is-small">
+              {{ entry.tag }}
+            </span>
+          </div>
+          <p v-if="entry.description" class="help has-text-grey mt-1 mb-0">
+            {{ entry.description }}
+          </p>
+          <p
+            v-if="entry.title"
+            class="help has-text-grey-light mt-1 mb-0 catalog-entry-url"
+            :title="entry.url"
+          >
+            {{ entry.url }}
+          </p>
+        </div>
+      </a>
+    </div>
+  </nav>
+</template>
+
+<style lang="scss" scoped>
+.catalog-title {
+  color: var(--bulma-label-color);
+  display: block;
+  font-size: var(--bulma-size-normal);
+  font-weight: var(--bulma-weight-semibold);
+}
+.catalog-panel {
+  margin-top: 1rem;
+  max-height: 400px;
+  // border-top: 1px solid var(--bulma-border);
+}
+
+.catalog-entries {
+  max-height: 45vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.catalog-entry {
+  display: block !important;
+  &:hover {
+    background-color: var(--bulma-link-light) !important;
+  }
+  border-bottom: 1px solid var(--bulma-border) !important;
+}
+
+.catalog-entry-content {
+  width: 100%;
+  min-width: 0;
+}
+
+.catalog-entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.catalog-entry-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.catalog-entry-header .tag {
+  flex-shrink: 0;
+}
+
+.catalog-entry-title {
+  display: block;
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.catalog-entry-url {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/ui/overlays/controls/DataInput.vue
+++ b/src/ui/overlays/controls/DataInput.vue
@@ -1,11 +1,18 @@
 <script lang="ts" setup>
-import { nextTick, ref, watch } from "vue";
+import { nextTick, onMounted, ref, watch } from "vue";
 
+import CatalogPanel from "./CatalogPanel.vue";
+
+import { useGlobeControlStore } from "@/store/store";
 import Modal from "@/ui/common/Modal.vue";
+import { fetchCatalog, type TCatalogEntry } from "@/utils/catalog";
 
 const props = defineProps<{ currentSource: string }>();
 
+const store = useGlobeControlStore();
+
 const visible = ref(false);
+const checking = ref(false);
 const dataPath = ref("");
 const datasetInput = ref<HTMLInputElement | null>(null);
 
@@ -33,14 +40,54 @@ function close() {
   visible.value = false;
 }
 
-function setLocationHash() {
+async function setLocationHash() {
+  console.log("set location hash?", dataPath.value);
   const next = dataPath.value.trim();
   if (!next) {
     return;
   }
+
+  checking.value = true;
+  try {
+    const data = await fetchCatalog(next);
+    if (data) {
+      store.catalogUrl = next;
+      store.catalogData = data;
+      dataPath.value = "";
+      return;
+    }
+  } catch {
+    /* fetch failed or timed out, proceed with normal loading */
+  } finally {
+    checking.value = false;
+  }
+
   location.hash = "#" + next;
   close();
 }
+
+function onCatalogSelect(entry: TCatalogEntry) {
+  const catUrl = store.catalogUrl;
+  location.hash =
+    "#" + entry.url + (catUrl ? "::catalog=" + encodeURIComponent(catUrl) : "");
+  close();
+}
+
+onMounted(async () => {
+  if (store.catalogUrl && !store.catalogData) {
+    try {
+      const data = await fetchCatalog(store.catalogUrl);
+      if (data) {
+        store.catalogData = data;
+        return;
+      }
+    } catch {
+      /* fetch failed or timed out, proceed with normal loading */
+    } finally {
+      checking.value = false;
+    }
+  }
+});
 </script>
 
 <template>
@@ -51,7 +98,7 @@ function setLocationHash() {
   >
     <form id="load-dataset" @submit.prevent="setLocationHash">
       <div class="field">
-        <label class="label" for="dataset-url">Dataset URL</label>
+        <label class="label" for="dataset-url">Dataset / Catalog URL</label>
         <div class="control has-icons-left">
           <input
             id="dataset-url"
@@ -59,7 +106,7 @@ function setLocationHash() {
             v-model="dataPath"
             class="input"
             type="url"
-            placeholder="Zarr URI"
+            placeholder="Zarr URI or catalog URL"
           />
           <span class="icon is-left">
             <i class="fa-solid fa-folder-open"></i>
@@ -67,10 +114,31 @@ function setLocationHash() {
         </div>
       </div>
     </form>
+
+    <CatalogPanel
+      v-if="store.catalogData"
+      :title="store.catalogData.title"
+      :datasets="store.catalogData.datasets"
+      @select="onCatalogSelect"
+    />
+
     <template #footer>
       <div class="buttons">
-        <button type="button" class="button" @click="close">Cancel</button>
-        <button type="submit" form="load-dataset" class="button is-success">
+        <button
+          type="button"
+          class="button"
+          :disabled="checking"
+          @click="close"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          form="load-dataset"
+          class="button is-success"
+          :class="{ 'is-loading': checking }"
+          :disabled="checking"
+        >
           Load
         </button>
       </div>

--- a/src/ui/overlays/controls/DataInput.vue
+++ b/src/ui/overlays/controls/DataInput.vue
@@ -41,28 +41,39 @@ function close() {
 }
 
 async function setLocationHash() {
-  console.log("set location hash?", dataPath.value);
   const next = dataPath.value.trim();
   if (!next) {
     return;
   }
+  const filenameToCheck = next.endsWith("/") ? next.slice(0, -1) : next;
+  // Catalogs are expected to be JSON files, so if the input ends with .json, we
+  // can try to fetch it as a catalog before setting the location hash
+  const isMaybeCatalog = filenameToCheck.endsWith(".json");
 
-  checking.value = true;
-  try {
-    const data = await fetchCatalog(next);
-    if (data) {
-      store.catalogUrl = next;
-      store.catalogData = data;
-      dataPath.value = "";
-      return;
+  if (isMaybeCatalog) {
+    checking.value = true;
+    try {
+      const data = await fetchCatalog(next);
+      if (data) {
+        store.catalogUrl = next;
+        store.catalogData = data;
+        dataPath.value = "";
+        return;
+      }
+    } catch {
+      /* fetch failed or timed out, proceed with normal loading */
+    } finally {
+      checking.value = false;
     }
-  } catch {
-    /* fetch failed or timed out, proceed with normal loading */
-  } finally {
-    checking.value = false;
   }
 
-  location.hash = "#" + next;
+  const catUrl = store.catalogUrl;
+  if (catUrl) {
+    location.hash =
+      "#" + next + (catUrl ? "::catalog=" + encodeURIComponent(catUrl) : "");
+  } else {
+    location.hash = "#" + next;
+  }
   close();
 }
 

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -1,0 +1,38 @@
+import axios from "axios";
+
+export type TCatalogEntry = {
+  url: string;
+  title?: string;
+  tag?: string;
+  description?: string;
+};
+
+export type TCatalog = {
+  type: "gridlook_catalog";
+  title?: string;
+  datasets: TCatalogEntry[];
+};
+
+export function isCatalog(data: unknown): data is TCatalog {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    (data as { type: unknown }).type === "gridlook_catalog" &&
+    "datasets" in data &&
+    Array.isArray((data as TCatalog).datasets)
+  );
+}
+
+export async function fetchCatalog(url: string): Promise<TCatalog | null> {
+  try {
+    const response = await axios.get(url);
+    const data = response.data;
+    if (isCatalog(data)) {
+      return data;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -24,9 +24,18 @@ export function isCatalog(data: unknown): data is TCatalog {
   );
 }
 
+function newAbortSignal(timeoutMs: number) {
+  const abortController = new AbortController();
+  setTimeout(() => abortController.abort(), timeoutMs || 0);
+
+  return abortController.signal;
+}
+
 export async function fetchCatalog(url: string): Promise<TCatalog | null> {
   try {
-    const response = await axios.get(url);
+    const response = await axios.get(url, {
+      signal: newAbortSignal(5000), //Aborts request after 5 seconds
+    });
     const data = response.data;
     if (isCatalog(data)) {
       return data;

--- a/src/utils/urlParams.ts
+++ b/src/utils/urlParams.ts
@@ -12,6 +12,7 @@ const URL_PARAMETERS = {
   PROJECTION_CENTER_LAT: "projectionCenterLat",
   PROJECTION_CENTER_LON: "projectionCenterLon",
   GRID_TYPE: "gridtype",
+  CATALOG: "catalog",
   DIM_INDICES: "dimIndices",
   DIM_MIN_BOUNDS: "dimMinBounds",
   DIM_MAX_BOUNDS: "dimMaxBounds",

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -185,9 +185,14 @@ watch(
     globeControlKey.value += 1;
     if (isDisplayMode.value || isPresenterActive.value) {
       // In display/presenter mode we want to preserve some state across source changes
-      store.resetExcept(["projectionMode", "projectionCenter"]);
+      store.resetExcept([
+        "projectionMode",
+        "projectionCenter",
+        "catalogData",
+        "catalogUrl",
+      ]);
     } else {
-      store.$reset();
+      store.resetExcept(["catalogData", "catalogUrl"]);
     }
     // stop loading is handled in the grid components after data load
     store.startLoading();

--- a/src/views/HashGlobeView.vue
+++ b/src/views/HashGlobeView.vue
@@ -16,6 +16,8 @@ type TParams = Partial<Record<TURLParameterValues, string>>;
 const DEFAULT_DATASET =
   "https://s3.eu-dkrz-1.dkrz.cloud/wrcp-hackathon/data/ICON/d3hp003.zarr/P1D_mean_z7_atm";
 
+const DEFAULT_CATALOG = "static/catalog.json";
+
 const defaultSrc = ref(DEFAULT_DATASET);
 const src = ref(DEFAULT_DATASET);
 const params: Ref<TParams> = ref({});
@@ -76,7 +78,9 @@ const onHashChange = () => {
       urlParameterStore[paramProperty] = value as any;
     }
     src.value = resource || defaultSrc.value;
+    store.catalogUrl = params.value.catalog || DEFAULT_CATALOG;
   } else {
+    store.catalogUrl = DEFAULT_CATALOG;
     src.value = defaultSrc.value;
   }
 };


### PR DESCRIPTION
This pull request adds support for loading and browsing dataset catalogs in GridLook. Users can now enter a catalog URL to view and select from a list of datasets, improving dataset discovery and selection. The UI has been updated to include a searchable and sortable catalog panel, and state management has been extended to handle catalog data and URLs.

The feature and the catalog format has been documented as well.

The datasets I have selected in the default catalog are open for discussion. The only important thing for me was that they are somewhat persistent for a while.