### PR TITLE
Fix/dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Pre-Versioning Changelog
+## Pre-Versioning Changelog
 
 For the period covered below, this changelog was organized in a conventional-commit-inspired format, inferred from merge request and pull request titles rather than commit messages.
 

--- a/src/lib/data/timeHandling.ts
+++ b/src/lib/data/timeHandling.ts
@@ -101,6 +101,10 @@ export function findTimeIndex(
   const firstValue = toNumber(timeArray[0]);
   const lastValue = toNumber(timeArray[n - 1]);
 
+  if (isNaN(targetValue) || isNaN(firstValue) || isNaN(lastValue)) {
+    throw new Error("Time array contains invalid values");
+  }
+
   // Handle out-of-bounds cases: clamp to array bounds
   if (targetValue < firstValue) {
     return 0;

--- a/src/lib/data/timeHandling.ts
+++ b/src/lib/data/timeHandling.ts
@@ -57,8 +57,12 @@ export function encodeTime(datetime: Dayjs, attrs: zarr.Attributes): number {
 /**
  * Converts a bigint or number to a number, handling BigInt64Array values.
  */
-function toNumber(value: number | bigint): number {
-  return typeof value === "bigint" ? Number(value) : value;
+function toNumber(value: number | bigint | string): number {
+  return typeof value === "bigint"
+    ? Number(value)
+    : typeof value === "string"
+      ? Number(value)
+      : value;
 }
 
 /**
@@ -80,7 +84,7 @@ function toNumber(value: number | bigint): number {
  */
 export function findTimeIndex(
   targetDatetime: Dayjs | string | Date,
-  timeArray: ArrayLike<number | bigint>,
+  timeArray: ArrayLike<number | bigint | string>,
   attrs: zarr.Attributes
 ): number {
   const target = dayjs.utc(targetDatetime);
@@ -137,7 +141,7 @@ export function findTimeIndex(
  */
 function binarySearchFloor(
   targetValue: number,
-  timeArray: ArrayLike<number | bigint>
+  timeArray: ArrayLike<number | bigint | string>
 ): number {
   let left = 0;
   let right = timeArray.length - 1;

--- a/src/lib/types/GlobeTypes.ts
+++ b/src/lib/types/GlobeTypes.ts
@@ -28,8 +28,8 @@ export type TDimensionRange = {
 export type TDimInfo =
   | EmptyObj
   | {
-      current: Dayjs | number;
-      values: Int32Array;
+      current: Dayjs | zarr.DataType;
+      values: zarr.TypedArray<zarr.DataType>;
       units?: string;
       attrs: zarr.Attributes;
       longName?: string;

--- a/src/lib/types/GlobeTypes.ts
+++ b/src/lib/types/GlobeTypes.ts
@@ -28,8 +28,8 @@ export type TDimensionRange = {
 export type TDimInfo =
   | EmptyObj
   | {
-      current: Dayjs | zarr.DataType;
-      values: zarr.TypedArray<zarr.DataType>;
+      current: Dayjs | number | bigint | string;
+      values: ArrayLike<number | bigint | string>;
       units?: string;
       attrs: zarr.Attributes;
       longName?: string;

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -207,7 +207,7 @@ async function getNside() {
 
 async function getCells() {
   try {
-    let cells = (
+    const rawCells = (
       await ZarrDataManager.getVariableData(
         ZarrDataManager.getDatasetSource(
           props.datasources!,
@@ -215,11 +215,9 @@ async function getCells() {
         ),
         "cell"
       )
-    ).data as Int32Array | BigInt64Array | number[];
-    if (typeof cells[0] === "bigint") {
-      cells = Array.from(cells, Number) as number[];
-    }
-    return cells as number[];
+    ).data as ArrayLike<number | bigint>;
+
+    return Array.from(rawCells, (cell) => Number(cell));
   } catch {
     return undefined;
   }
@@ -727,9 +725,15 @@ async function fetchAndRenderData(
   hoverData.value = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
   );
-  hoverCellIndexMap.value = cellCoord
-    ? new Map(cellCoord.map((pixel, index) => [pixel, index]))
-    : null;
+  if (cellCoord) {
+    const cellIndexMap = new Map<number, number>();
+    for (let index = 0; index < cellCoord.length; index++) {
+      cellIndexMap.set(cellCoord[index], index);
+    }
+    hoverCellIndexMap.value = cellIndexMap;
+  } else {
+    hoverCellIndexMap.value = null;
+  }
   setHoverLookup(healpixHoverLookup);
   const { dataMin, dataMax, histogramSummaries } = await processHealpixChunks(
     datavar,

--- a/src/ui/grids/composables/useGridDataAccess.ts
+++ b/src/ui/grids/composables/useGridDataAccess.ts
@@ -89,23 +89,32 @@ export function useGridDataAccess() {
         [null]
       );
 
-      let dimValues = dimArray.data as
-        | zarr.TypedArray<zarr.DataType>
-        | string[];
+      type TCoordinateValue = number | bigint | string;
+
+      const rawValues = dimArray.data;
+      let dimValues: ArrayLike<TCoordinateValue>;
+      let current: TCoordinateValue;
+
       if (
-        dimValues instanceof zarr.UnicodeStringArray ||
-        dimValues instanceof zarr.ByteStringArray
+        rawValues instanceof zarr.UnicodeStringArray ||
+        rawValues instanceof zarr.ByteStringArray
       ) {
-        dimValues = [...dimValues] as string[];
+        const stringValues = [...rawValues];
+        dimValues = stringValues;
+        current = stringValues[index] as TCoordinateValue;
+      } else {
+        const numericValues = rawValues as ArrayLike<TCoordinateValue>;
+        dimValues = numericValues;
+        current = numericValues[index] as TCoordinateValue;
       }
-      const indexable = dimValues as { [n: number]: unknown };
+
       const dimvar = await ZarrDataManager.getVariableInfo(
         datasource,
         dimensionName
       );
       return {
         values: dimValues,
-        current: indexable[index] as zarr.DataType,
+        current,
         attrs: dimvar.attrs,
         units: dimvar.attrs.units as string,
         longName: (dimvar.attrs.long_name ??

--- a/src/ui/grids/composables/useGridDataAccess.ts
+++ b/src/ui/grids/composables/useGridDataAccess.ts
@@ -1,6 +1,6 @@
 import type { ShallowRef } from "vue";
 import { shallowRef } from "vue";
-import type * as zarr from "zarrita";
+import * as zarr from "zarrita";
 
 import { decodeTime } from "@/lib/data/timeHandling.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
@@ -54,7 +54,6 @@ export function useGridDataAccess() {
     }
     try {
       const myDatasource = datasources!.levels[0].time;
-
       const timevalues = (
         await ZarrDataManager.getVariableData(myDatasource, "time", [null])
       ).data as Int32Array;
@@ -84,17 +83,29 @@ export function useGridDataAccess() {
         return {};
       }
 
-      const dimValues = (
-        await ZarrDataManager.getVariableData(datasource, dimensionName, [null])
-      ).data as Int32Array;
+      const dimArray = await ZarrDataManager.getVariableData(
+        datasource,
+        dimensionName,
+        [null]
+      );
 
+      let dimValues = dimArray.data as
+        | zarr.TypedArray<zarr.DataType>
+        | string[];
+      if (
+        dimValues instanceof zarr.UnicodeStringArray ||
+        dimValues instanceof zarr.ByteStringArray
+      ) {
+        dimValues = [...dimValues] as string[];
+      }
+      const indexable = dimValues as { [n: number]: unknown };
       const dimvar = await ZarrDataManager.getVariableInfo(
         datasource,
         dimensionName
       );
       return {
         values: dimValues,
-        current: dimValues[index],
+        current: indexable[index] as zarr.DataType,
         attrs: dimvar.attrs,
         units: dimvar.attrs.units as string,
         longName: (dimvar.attrs.long_name ??

--- a/src/ui/grids/composables/useGridDataAccess.ts
+++ b/src/ui/grids/composables/useGridDataAccess.ts
@@ -46,9 +46,10 @@ export function useGridDataAccess() {
   async function getTimeInfo(
     datasources: TSources,
     dimensionRanges: TDimensionRange[],
+    dimensionIndex: number,
     index: number
   ): Promise<TDimInfo> {
-    if (dimensionRanges[0]?.name !== "time") {
+    if (dimensionRanges[dimensionIndex]?.name !== "time") {
       return {};
     }
     try {

--- a/src/ui/grids/composables/useSharedGridLogic.ts
+++ b/src/ui/grids/composables/useSharedGridLogic.ts
@@ -185,19 +185,21 @@ export function useSharedGridLogic() {
     dimSlidersValues: (number | zarr.Slice | null)[]
   ): Promise<TDimInfo[]> {
     const array: TDimInfo[] = [];
-    for (const dim of dimensionRanges) {
+    for (let i = 0; i < dimensionRanges.length; i++) {
+      const dim = dimensionRanges[i];
       if (dim?.name === "time") {
         const timeInfo = await getTimeInfo(
           datasources,
           dimensionRanges,
-          dimSlidersValues[0] as number
+          i,
+          dimSlidersValues[i] as number
         );
         array.push(timeInfo);
       } else {
         const dimInfo = await getDimensionInfo(
           datasources.levels[0].datasources[currentVariable],
           dim!,
-          dimSlidersValues[dimensionRanges.indexOf(dim)] as number
+          dimSlidersValues[i] as number
         );
         array.push(dimInfo);
       }

--- a/src/ui/overlays/controls/DatetimePicker.vue
+++ b/src/ui/overlays/controls/DatetimePicker.vue
@@ -8,7 +8,7 @@ import { findTimeIndex, decodeTime } from "@/lib/data/timeHandling";
 import Modal from "@/ui/common/Modal.vue";
 
 const props = defineProps<{
-  timeValues: ArrayLike<number | bigint> | null;
+  timeValues: ArrayLike<number | bigint | string> | null;
   timeAttrs: Record<string, unknown> | null;
   currentIndex: number;
   minIndex: number;
@@ -29,38 +29,32 @@ const errorMessage = ref<string | null>(null);
 
 // Compute the datetime range for display
 const minDatetime = computed(() => {
-  if (!props.timeValues || !props.timeAttrs || props.timeValues.length === 0) {
-    return null;
-  }
-  const val = props.timeValues[props.minIndex];
-  return decodeTime(
-    typeof val === "bigint" ? Number(val) : val,
-    props.timeAttrs
-  );
+  return decodeTimeAtIndex(props.minIndex);
 });
 
 const maxDatetime = computed(() => {
-  if (!props.timeValues || !props.timeAttrs || props.timeValues.length === 0) {
-    return null;
-  }
-  const val = props.timeValues[props.maxIndex];
-  return decodeTime(
-    typeof val === "bigint" ? Number(val) : val,
-    props.timeAttrs
-  );
+  return decodeTimeAtIndex(props.maxIndex);
 });
 
 // Current datetime at the selected index
 const currentDatetime = computed(() => {
+  return decodeTimeAtIndex(props.currentIndex);
+});
+
+function decodeTimeAtIndex(index: number): Dayjs | null {
   if (!props.timeValues || !props.timeAttrs || props.timeValues.length === 0) {
     return null;
   }
-  const val = props.timeValues[props.currentIndex];
+  const val = props.timeValues[index];
   return decodeTime(
-    typeof val === "bigint" ? Number(val) : val,
+    typeof val === "bigint"
+      ? Number(val)
+      : typeof val === "string"
+        ? Number(val)
+        : val,
     props.timeAttrs
   );
-});
+}
 
 // Initialize input with current datetime when opening
 watch(isOpen, (open) => {
@@ -105,11 +99,7 @@ function onInputChange() {
     previewIndex.value = index;
 
     // Show the actual datetime at that index
-    const val = props.timeValues[index];
-    previewDatetime.value = decodeTime(
-      typeof val === "bigint" ? Number(val) : val,
-      props.timeAttrs
-    );
+    previewDatetime.value = decodeTimeAtIndex(index);
   } catch (e) {
     errorMessage.value =
       e instanceof Error ? e.message : "Error parsing datetime";

--- a/src/ui/overlays/controls/DimensionControl.vue
+++ b/src/ui/overlays/controls/DimensionControl.vue
@@ -110,11 +110,7 @@ function capitalize(str: string): string {
             {{ capitalize(range.name) }}:
             <DatetimePicker
               v-if="range.name === 'time'"
-              :time-values="
-                (varinfo.dimInfo[index]?.values as ArrayLike<
-                  number | bigint | string
-                > | null) ?? []
-              "
+              :time-values="varinfo.dimInfo[index]?.values ?? []"
               :time-attrs="varinfo.dimInfo[index]?.attrs ?? {}"
               :current-index="localSliders[index] ?? 0"
               :min-index="range?.minBound ?? 0"

--- a/src/ui/overlays/controls/DimensionControl.vue
+++ b/src/ui/overlays/controls/DimensionControl.vue
@@ -110,7 +110,11 @@ function capitalize(str: string): string {
             {{ capitalize(range.name) }}:
             <DatetimePicker
               v-if="range.name === 'time'"
-              :time-values="varinfo.dimInfo[index]?.values ?? []"
+              :time-values="
+                (varinfo.dimInfo[index]?.values as ArrayLike<
+                  number | bigint | string
+                > | null) ?? []
+              "
               :time-attrs="varinfo.dimInfo[index]?.attrs ?? {}"
               :current-index="localSliders[index] ?? 0"
               :min-index="range?.minBound ?? 0"


### PR DESCRIPTION
The following dataset has three adjustable dimensions and has properties which were not covered before:

 * time dimension is not the first dimension
 * member_id contains strings instead of numbers

This resulted in missing information for the current value of the respective dimension.
Both issues have been fixed.

https://gridlook.pages.dev/#https://ncar-cesm2-lens.s3.amazonaws.com/atm/daily/cesm2LE-historical-cmip6-Z3.zarr/::varname=Z3

Besides that I made a subtitle out of the the first headline of the old changelog. Apparently `release-please` started to stuff the new changelogs under the old headline, which was not the behaviour I saw in my private repo where it created a new `Changelog`-Title by itself. I hope it will now get the gist.

Edit:

I fixed also one Healpix issue where the dataset could not be rendered when coordinates were provided. This issue was introduced with the hover data-feature. Example Dataset:

https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_7.zarr