### PR TITLE
Projection performance and Windows-Stability

### DIFF
--- a/src/lib/data/zarrUtils.ts
+++ b/src/lib/data/zarrUtils.ts
@@ -377,6 +377,25 @@ export function getDataBounds(
     missingValue: missingValue,
   };
 }
+
+export function mapMissingAndFillToNaN(
+  data: Float32Array<ArrayBufferLike>,
+  missingValue: number,
+  fillValue: number
+) {
+  for (let i = 0; i < data.length; i++) {
+    const value = data[i];
+    if (
+      !Number.isFinite(value) ||
+      value === missingValue ||
+      value === fillValue
+    ) {
+      data[i] = NaN;
+    }
+  }
+  return data;
+}
+
 /**
  * Gridlook cannot handle Float64 and integer types in textures, so cast to Float32
  */

--- a/src/lib/layers/gpuProjectedLines.ts
+++ b/src/lib/layers/gpuProjectedLines.ts
@@ -144,9 +144,6 @@ export function makeGpuProjectedLineMaterial(
     },
     transparent: true,
     depthWrite: false,
-    polygonOffset: true,
-    polygonOffsetFactor: -1,
-    polygonOffsetUnits: -1,
     vertexShader: gpuProjectedLineVertexShader,
     fragmentShader: gpuProjectedLineFragmentShader,
   });
@@ -164,4 +161,5 @@ export function updateGpuProjectedLineMaterial(
   material.uniforms.centerLat.value = helper.center.lat;
   material.uniforms.projectionRadius.value = options.radius;
   material.uniforms.zOffset.value = options.zOffset;
+  material.depthTest = !helper.isFlat;
 }

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -234,10 +234,9 @@ vec3 inverseMercator(float x, float y) {
 }
 
 vec3 inverseCylindricalEqualArea(float x, float y) {
-  float k = 1.2792006328649603;
-  float sinLat = y / k;
+  float sinLat = y / CYLINDRICAL_EQUAL_AREA_SCALE;
   if (abs(sinLat) > 1.0) return vec3(0.0, 0.0, -1.0);
-  float rLon = x * k * RAD_TO_DEG;
+  float rLon = x * CYLINDRICAL_EQUAL_AREA_SCALE * RAD_TO_DEG;
   if (abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
   return vec3(asin(sinLat) * RAD_TO_DEG, rLon, 1.0);
 }
@@ -265,28 +264,35 @@ vec3 inverseRobinson(float x, float y) {
   float absY = abs(y);
   if (absY > robinsonK[39]) return vec3(0.0, 0.0, -1.0);
 
-  // Linear search through Y coefficients to find the latitude band
-  int band = 1;
-  for (int i = 2; i <= 19; i++) {
-    if (robinsonK[i * 2 + 1] > absY) {
-      band = i - 1;
+  int i0 = 0;
+  for (int i = 0; i <= 17; i++) {
+    if (absY <= robinsonK[(i + 2) * 2 + 1]) {
+      i0 = i;
       break;
     }
-    band = i;
+    i0 = i;
   }
 
-  float y0 = robinsonK[band * 2 + 1];
-  float y1 = robinsonK[(band + 1) * 2 + 1];
-  float frac = (abs(y1 - y0) > 0.0001) ? (absY - y0) / (y1 - y0) : 0.0;
+  float ax = robinsonK[i0 * 2];
+  float ay = robinsonK[i0 * 2 + 1];
+  float bx = robinsonK[(i0 + 1) * 2];
+  float by = robinsonK[(i0 + 1) * 2 + 1];
+  float cx = robinsonK[(i0 + 2) * 2];
+  float cy = robinsonK[(i0 + 2) * 2 + 1];
 
-  // Each band spans 5 degrees; band 1 = 0 degrees
-  float latDeg = (float(band - 1) + frac) * 5.0;
+  float di = (abs(cy - by) > 0.0001) ? (absY - by) / (cy - by) : 0.0;
+  di = clamp(di, 0.0, 1.0);
+  for (int iter = 0; iter < 5; iter++) {
+    float yCoeff = by + di * (cy - ay) / 2.0 + di * di * (cy - 2.0 * by + ay) / 2.0;
+    float dyCoeff = (cy - ay) / 2.0 + di * (cy - 2.0 * by + ay);
+    if (abs(dyCoeff) < 0.0001) break;
+    di = clamp(di - (yCoeff - absY) / dyCoeff, 0.0, 1.0);
+  }
+
+  float latDeg = (float(i0) + di) * 5.0;
   if (y < 0.0) latDeg = -latDeg;
 
-  float x0 = robinsonK[band * 2];
-  float x1 = robinsonK[(band + 1) * 2];
-  float xCoeff = mix(x0, x1, frac);
-
+  float xCoeff = bx + di * (cx - ax) / 2.0 + di * di * (cx - 2.0 * bx + ax) / 2.0;
   if (abs(xCoeff) < 0.0001) return vec3(0.0, 0.0, -1.0);
   float rLon = (x / xCoeff) * RAD_TO_DEG;
   if (abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -108,151 +108,24 @@ function copyAntimeridianEdge(ctx: CanvasRenderingContext2D, width: number) {
   ctx.putImageData(edge, width - 1, 0);
 }
 
-// =============================================================================
-// Globe Mask Renderer (3D sphere)
-// =============================================================================
-
-class GlobeMaskRenderer {
-  static async render(
-    mode: TLandSeaMaskMode,
-    useTexture: boolean
-  ): Promise<THREE.Mesh | undefined> {
-    let mesh: THREE.Mesh | undefined;
-
-    switch (mode) {
-      case LAND_SEA_MASK_MODES.GLOBE:
-        mesh = useTexture
-          ? await this.createTexturedGlobe()
-          : await this.createColoredGlobe();
-        break;
-      case LAND_SEA_MASK_MODES.SEA:
-      case LAND_SEA_MASK_MODES.LAND:
-        mesh = useTexture
-          ? await this.createMaskedTexture(mode === LAND_SEA_MASK_MODES.LAND)
-          : await this.createMaskedSolid(mode === LAND_SEA_MASK_MODES.LAND);
-        break;
-      default:
-        mesh = undefined;
-    }
-
-    if (mesh && isGlobeMaskMode(mode)) {
-      const material = mesh.material as THREE.MeshBasicMaterial;
-      material.depthWrite = false;
-      material.depthTest = true;
-    }
-
-    return mesh;
+/**
+ * Threshold all alpha values to be exactly 0 or 255.
+ * Canvas2D anti-aliases path edges, creating semi-transparent fringe pixels.
+ * Those fringe pixels are discarded by the shader's `a < 0.01` test, which
+ * makes mask edges look blurry/recessed when zoomed in.  Hard-quantising the
+ * alpha produces the same sharp coastline appearance as the globe mask.
+ */
+function thresholdAlpha(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number
+) {
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  for (let i = 3; i < data.length; i += 4) {
+    data[i] = data[i] > 127 ? 255 : 0;
   }
-
-  private static async createTexturedGlobe(): Promise<THREE.Mesh> {
-    const img = await ResourceCache.loadImage(albedo);
-    const texture = new THREE.Texture(img);
-    texture.needsUpdate = true;
-
-    return this.createSphereMesh(texture, 0.999, false);
-  }
-
-  private static async createColoredGlobe(): Promise<THREE.Mesh> {
-    const { canvas, ctx, width, height } = CanvasFactory.create();
-    const land = await ResourceCache.loadLandGeoJSON();
-    const projection = D3ProjectionFactory.createEquirectangular(width, height);
-    const path = d3.geoPath(projection, ctx);
-
-    // Draw ocean background
-    ctx.fillStyle = MASK_COLORS.sea;
-    ctx.fillRect(0, 0, width, height);
-
-    // Draw land
-    ctx.beginPath();
-    path(land);
-    ctx.fillStyle = MASK_COLORS.land;
-    ctx.fill();
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.anisotropy = 16;
-    texture.needsUpdate = true;
-
-    return this.createSphereMesh(texture, 0.999, false);
-  }
-
-  private static async createMaskedTexture(
-    showLandOnly: boolean
-  ): Promise<THREE.Mesh> {
-    const { canvas, ctx, width, height } = CanvasFactory.create();
-    const [land, img] = await Promise.all([
-      ResourceCache.loadLandGeoJSON(),
-      ResourceCache.loadImage(albedo),
-    ]);
-
-    // Draw earth texture
-    ctx.drawImage(img, 0, 0, width, height);
-
-    // Create projection and path
-    const projection = D3ProjectionFactory.createEquirectangular(width, height);
-    const path = d3.geoPath(projection, ctx);
-
-    // Mask out unwanted area
-    ctx.beginPath();
-    path(land);
-    ctx.globalCompositeOperation = showLandOnly
-      ? "destination-in"
-      : "destination-out";
-    ctx.fill();
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.needsUpdate = true;
-
-    return this.createSphereMesh(texture, 1.002);
-  }
-
-  private static async createMaskedSolid(
-    showLandOnly: boolean
-  ): Promise<THREE.Mesh> {
-    const { canvas, ctx, width, height } = CanvasFactory.create();
-    const land = await ResourceCache.loadLandGeoJSON();
-    const projection = D3ProjectionFactory.createEquirectangular(width, height);
-    const path = d3.geoPath(projection, ctx);
-
-    if (!showLandOnly) {
-      // Fill with sea color, then cut out land
-      ctx.fillStyle = MASK_COLORS.sea;
-      ctx.fillRect(0, 0, width, height);
-      ctx.beginPath();
-      path(land);
-      ctx.globalCompositeOperation = "destination-out";
-      ctx.fill();
-    } else {
-      // Just draw land
-      ctx.beginPath();
-      path(land);
-      ctx.fillStyle = MASK_COLORS.land;
-      ctx.fill();
-    }
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.anisotropy = 16;
-    texture.needsUpdate = true;
-
-    return this.createSphereMesh(texture, 1.002);
-  }
-
-  private static createSphereMesh(
-    texture: THREE.Texture,
-    radius: number,
-    transparent = true
-  ): THREE.Mesh {
-    const geometry = new THREE.SphereGeometry(radius, 64, 64);
-    const material = new THREE.MeshBasicMaterial({
-      map: texture,
-      transparent,
-      side: THREE.FrontSide,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.name = "mask";
-    mesh.renderOrder = 1;
-    mesh.rotation.x = Math.PI / 2;
-    return mesh;
-  }
+  ctx.putImageData(imageData, 0, 0);
 }
 
 /**
@@ -540,16 +413,15 @@ class GpuProjectedMaskRenderer {
     let material: THREE.ShaderMaterial;
 
     if (projectionHelper.isFlat) {
-      geometry = this.createFlatQuadGeometry(mode);
+      geometry = this.createFlatQuadGeometry();
       material = this.createFlatInverseMaterial(
         texture,
-        mode,
         getProjectionTypeFromMode(projectionHelper.type),
         projectionHelper.center
       );
     } else {
       geometry = this.createGlobeGeometry();
-      material = this.createGlobeMaterial(texture, mode);
+      material = this.createGlobeMaterial(texture);
     }
 
     const mesh = new THREE.Mesh(geometry, material);
@@ -602,11 +474,13 @@ class GpuProjectedMaskRenderer {
    * Create a quad covering the flat projection's coordinate space.
    * The fragment shader handles clipping to the actual projection boundary.
    */
-  private static createFlatQuadGeometry(
-    mode?: TLandSeaMaskMode
-  ): THREE.BufferGeometry {
-    const isBackground = mode ? isGlobeMaskMode(mode) : true;
-    const zOffset = isBackground ? -0.01 : 0.01;
+  private static createFlatQuadGeometry(): THREE.BufferGeometry {
+    // All flat mask quads sit at z=0.  depthTest is disabled on the material
+    // so depth has no effect on layering; renderOrder handles that exclusively.
+    // Using different z offsets per mode caused perspective-camera scaling
+    // differences: the land/sea quads (z=+0.01) appeared ~1% larger than the
+    // globe quad (z=-0.01), making land shapes look "more zoomed in".
+    const zOffset = 0;
     const extent = 4.0; // generous extent covering all projection types
 
     const vertices = new Float32Array([
@@ -689,14 +563,14 @@ class GpuProjectedMaskRenderer {
    * Create the shader material for GPU-projected globe mask.
    */
   private static createGlobeMaterial(
-    texture: THREE.Texture,
-    mode: TLandSeaMaskMode
+    texture: THREE.Texture
   ): THREE.ShaderMaterial {
-    const globeMode = isGlobeMaskMode(mode);
-
-    // For globe mode (full earth background), use smaller radius so it's behind data
-    // For overlay masks (land-only or sea-only), use larger radius so they're in front of data
-    const radius = globeMode ? 0.998 : 1.003;
+    // All masks sit at radius 1.003, matching the coastline layer, so there is no
+    // parallax drift when the camera orbits. Layering is handled purely via renderOrder:
+    //   globe mask = -1 (background, depthWrite: false)
+    //   land/sea masks = 10 (above data)
+    //   coastlines/graticules = 20 (always on top)
+    const radius = 1.003;
 
     const material = new THREE.ShaderMaterial({
       uniforms: {
@@ -709,7 +583,11 @@ class GpuProjectedMaskRenderer {
       transparent: true,
       side: THREE.FrontSide,
       depthWrite: false,
-      depthTest: true,
+      // depthTest: false so rendering order is controlled solely by renderOrder.
+      // The globe mask (renderOrder = -1) always paints first as a background;
+      // relying on the depth buffer here is unnecessary and was preventing proper
+      // layering at non-standard camera angles.
+      depthTest: false,
     });
 
     return material;
@@ -720,7 +598,6 @@ class GpuProjectedMaskRenderer {
    */
   private static createFlatInverseMaterial(
     texture: THREE.Texture,
-    mode: TLandSeaMaskMode,
     projectionType: number,
     center: { lat: number; lon: number }
   ): THREE.ShaderMaterial {
@@ -739,11 +616,6 @@ class GpuProjectedMaskRenderer {
       depthWrite: false,
       depthTest: false,
     });
-
-    // Use polygon offset to prevent z-fighting
-    material.polygonOffset = true;
-    material.polygonOffsetFactor = isGlobeMaskMode(mode) ? 1 : -1;
-    material.polygonOffsetUnits = isGlobeMaskMode(mode) ? 1 : -1;
 
     return material;
   }
@@ -778,6 +650,9 @@ class GpuProjectedMaskRenderer {
         ? "destination-in"
         : "destination-out";
       ctx.fill();
+      // Restore composite mode before the alpha threshold pass
+      ctx.globalCompositeOperation = "source-over";
+      thresholdAlpha(ctx, width, height);
       return;
     }
 
@@ -789,6 +664,7 @@ class GpuProjectedMaskRenderer {
         path(land);
         ctx.globalCompositeOperation = "destination-out";
         ctx.fill();
+        ctx.globalCompositeOperation = "source-over";
       }
     }
 
@@ -815,6 +691,7 @@ class GpuProjectedMaskRenderer {
       return;
     }
 
+    // Fill with sea colour, then paint land on top.
     ctx.fillStyle = MASK_COLORS.sea;
     ctx.fillRect(0, 0, width, height);
 
@@ -838,7 +715,22 @@ class GpuProjectedMaskRenderer {
       return this.createGlobeTexture();
     }
 
-    const { canvas, ctx, width, height } = CanvasFactory.create();
+    // When textures are enabled, create the canvas at the earth image's native
+    // resolution so the mask cutout matches the photo pixel-for-pixel.
+    // For solid-colour masks we stay at 4096×2048 because complex d3 polygon
+    // fills can exceed browser canvas path limits at higher resolutions.
+    let canvasWidth = 4096;
+    let canvasHeight = 2048;
+    if (useTexture) {
+      const img = await ResourceCache.loadImage(albedo);
+      canvasWidth = img.naturalWidth;
+      canvasHeight = img.naturalHeight;
+    }
+
+    const { canvas, ctx, width, height } = CanvasFactory.create(
+      canvasWidth,
+      canvasHeight
+    );
     const land = await ResourceCache.loadLandGeoJSON();
     const projection = D3ProjectionFactory.createEquirectangular(width, height);
     const path = d3.geoPath(projection, ctx);
@@ -880,26 +772,22 @@ export async function getLandSeaMask(
   landSeaMaskUseTexture: boolean,
   projectionHelper?: ProjectionHelper
 ): Promise<THREE.Object3D | undefined> {
-  const choice = landSeaMaskChoice ?? LAND_SEA_MASK_MODES.OFF;
-  const useTexture = landSeaMaskUseTexture;
+  if (landSeaMaskChoice === LAND_SEA_MASK_MODES.OFF) {
+    return undefined;
+  }
 
-  if (choice === LAND_SEA_MASK_MODES.OFF) {
+  if (!projectionHelper) {
     return undefined;
   }
 
   try {
-    // Use GPU-projected renderer for all projections
-    // This allows instant projection center changes without rebuilding
-    if (projectionHelper) {
-      return await GpuProjectedMaskRenderer.render(
-        choice,
-        useTexture,
-        projectionHelper
-      );
-    }
-
-    // Fallback to globe renderer if no projection helper
-    return await GlobeMaskRenderer.render(choice, useTexture);
+    // Use GPU-projected renderer for all projections.
+    // Projection center changes only update uniforms — no geometry rebuild needed.
+    return await GpuProjectedMaskRenderer.render(
+      landSeaMaskChoice,
+      landSeaMaskUseTexture,
+      projectionHelper
+    );
   } catch {
     return undefined;
   }

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -8,13 +8,7 @@ import {
   projectionShaderFunctions,
   getProjectionTypeFromMode,
 } from "@/lib/projection/projectionShaders";
-import {
-  AZIMUTHAL_CLIP_ANGLE,
-  MERCATOR_LAT_LIMIT,
-  PROJECTION_TYPES,
-  ProjectionHelper,
-  isAzimuthalProjectionType,
-} from "@/lib/projection/projectionUtils";
+import { ProjectionHelper } from "@/lib/projection/projectionUtils";
 
 export const LAND_SEA_MASK_MODES = {
   OFF: "off",
@@ -29,15 +23,6 @@ export const LAND_SEA_MASK_MODES = {
 
 export type TLandSeaMaskMode =
   (typeof LAND_SEA_MASK_MODES)[keyof typeof LAND_SEA_MASK_MODES];
-
-type TMaskContext = {
-  vertices: number[];
-  angularDistances: number[];
-  isAzimuthal: boolean;
-  lonSegments: number;
-  threshold: number;
-  straddleMultiplier: number;
-};
 
 type TMaskConfig = {
   showLand: boolean;
@@ -105,6 +90,22 @@ class CanvasFactory {
     ctx.clearRect(0, 0, width, height);
     return { canvas, ctx, width, height };
   }
+}
+
+function configureEquirectangularTexture(texture: THREE.Texture) {
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.anisotropy = 16;
+  texture.generateMipmaps = false;
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function copyAntimeridianEdge(ctx: CanvasRenderingContext2D, width: number) {
+  const edge = ctx.getImageData(0, 0, 1, ctx.canvas.height);
+  ctx.putImageData(edge, width - 1, 0);
 }
 
 // =============================================================================
@@ -259,54 +260,37 @@ class GlobeMaskRenderer {
  * Projects lat/lon coordinates on the GPU.
  */
 const gpuProjectedMaskVertexShader = `
-${projectionShaderFunctions}
-
-uniform int projectionType;
-uniform float centerLon;
-uniform float centerLat;
 uniform float projectionRadius;
 
-attribute vec2 latLon;
-
-varying vec2 vUv;
+varying vec3 vSpherePosition;
 
 void main() {
-  vUv = uv;
-  vec3 projected = projectLatLon(
-    latLon.x,
-    latLon.y,
-    projectionType,
-    centerLon,
-    centerLat,
-    projectionRadius
-  );
+  vSpherePosition = normalize(position);
+  vec3 projected = position * projectionRadius;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(projected, 1.0);
 }
 `;
 
 /**
- * Simple vertex shader for pre-projected flat mask geometry.
- */
-const flatMaskVertexShader = `
-varying vec2 vUv;
-
-void main() {
-  vUv = uv;
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-}
-`;
-
-/**
- * Fragment shader for mask rendering.
+ * Fragment shader for globe mask rendering.
+ * Computes UV from interpolated lat/lon rather than from a UV attribute,
+ * so there is no 0/1 discontinuity at the antimeridian.
  */
 const gpuProjectedMaskFragmentShader = `
+#define PI 3.141592653589793
+
 uniform sampler2D maskTexture;
 uniform float opacity;
 
-varying vec2 vUv;
+varying vec3 vSpherePosition;
 
 void main() {
-  vec4 texColor = texture2D(maskTexture, vUv);
+  vec3 spherePosition = normalize(vSpherePosition);
+  float lon = atan(spherePosition.y, spherePosition.x);
+  float lat = asin(clamp(spherePosition.z, -1.0, 1.0));
+  float u = (lon + PI) / (2.0 * PI);
+  float v = (lat + PI * 0.5) / PI;
+  vec4 texColor = texture2D(maskTexture, vec2(u, v));
   if (texColor.a < 0.01) {
     discard;
   }
@@ -315,10 +299,191 @@ void main() {
 `;
 
 /**
- * Fragment shader for flat mask rendering.
+ * Vertex shader for flat mask: passes projected coordinates to fragment shader.
  */
-const flatMaskFragmentShader = `
+const flatInverseVertexShader = `
+varying vec2 vProjectedCoord;
+
+void main() {
+  vProjectedCoord = position.xy;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+/**
+ * Fragment shader for flat mask: inverse-projects screen coordinates to lat/lon
+ * and samples the equirectangular mask texture. Eliminates geometry rebuilds
+ * when the projection center changes (rotation).
+ */
+const flatInverseFragmentShader = `
 ${projectionShaderFunctions}
+
+// Unrotate: inverse of rotateCoords. Recovers geographic (lat, lon) from
+// the rotated frame produced by the forward projection.
+vec2 unrotateCoords(float rotatedLat, float rotatedLon, float cLon, float cLat) {
+  float latRad = rotatedLat * DEG_TO_RAD;
+  float lonRad = rotatedLon * DEG_TO_RAD;
+  float cLatRad = cLat * DEG_TO_RAD;
+
+  float cosLat = cos(latRad);
+  float sinLat = sin(latRad);
+  float cosLon = cos(lonRad);
+  float sinLon = sin(lonRad);
+  float cosCLat = cos(cLatRad);
+  float sinCLat = sin(cLatRad);
+
+  float newSinLat = sinLat * cosCLat + cosLat * cosLon * sinCLat;
+  float newLat = asin(clamp(newSinLat, -1.0, 1.0));
+
+  float y = cosLat * sinLon;
+  float x = cosLat * cosLon * cosCLat - sinLat * sinCLat;
+  float newLon = atan(y, x) + cLon * DEG_TO_RAD;
+
+  return vec2(newLat * RAD_TO_DEG, newLon * RAD_TO_DEG);
+}
+
+// --- Inverse projection functions ---
+// Each returns vec3(rotatedLat, rotatedLon, valid).
+// valid < 0 means the point is outside the projection domain.
+
+vec3 inverseEquirectangular(float x, float y) {
+  float rLon = x * RAD_TO_DEG;
+  float rLat = y * RAD_TO_DEG;
+  if (abs(rLat) > 90.0 || abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
+  return vec3(rLat, rLon, 1.0);
+}
+
+vec3 inverseMercator(float x, float y) {
+  float rLon = x * RAD_TO_DEG;
+  float rLat = (2.0 * atan(exp(y)) - PI * 0.5) * RAD_TO_DEG;
+  if (abs(rLat) > MERCATOR_LAT_LIMIT || abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
+  return vec3(rLat, rLon, 1.0);
+}
+
+vec3 inverseCylindricalEqualArea(float x, float y) {
+  float k = 1.2792006328649603;
+  float sinLat = y / k;
+  if (abs(sinLat) > 1.0) return vec3(0.0, 0.0, -1.0);
+  float rLon = x * k * RAD_TO_DEG;
+  if (abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
+  return vec3(asin(sinLat) * RAD_TO_DEG, rLon, 1.0);
+}
+
+vec3 inverseMollweide(float x, float y) {
+  float sinTheta = y / sqrt(2.0);
+  if (abs(sinTheta) > 1.0) return vec3(0.0, 0.0, -1.0);
+  float theta = asin(sinTheta);
+  float cosTheta = cos(theta);
+
+  float rLon;
+  if (abs(cosTheta) < 0.0001) {
+    rLon = 0.0;
+  } else {
+    rLon = (PI * x / (2.0 * sqrt(2.0) * cosTheta)) * RAD_TO_DEG;
+  }
+  if (abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
+
+  float sinLatVal = (2.0 * theta + sin(2.0 * theta)) / PI;
+  if (abs(sinLatVal) > 1.0) return vec3(0.0, 0.0, -1.0);
+  return vec3(asin(sinLatVal) * RAD_TO_DEG, rLon, 1.0);
+}
+
+vec3 inverseRobinson(float x, float y) {
+  float absY = abs(y);
+  if (absY > robinsonK[39]) return vec3(0.0, 0.0, -1.0);
+
+  // Linear search through Y coefficients to find the latitude band
+  int band = 1;
+  for (int i = 2; i <= 19; i++) {
+    if (robinsonK[i * 2 + 1] > absY) {
+      band = i - 1;
+      break;
+    }
+    band = i;
+  }
+
+  float y0 = robinsonK[band * 2 + 1];
+  float y1 = robinsonK[(band + 1) * 2 + 1];
+  float frac = (abs(y1 - y0) > 0.0001) ? (absY - y0) / (y1 - y0) : 0.0;
+
+  // Each band spans 5 degrees; band 1 = 0 degrees
+  float latDeg = (float(band - 1) + frac) * 5.0;
+  if (y < 0.0) latDeg = -latDeg;
+
+  float x0 = robinsonK[band * 2];
+  float x1 = robinsonK[(band + 1) * 2];
+  float xCoeff = mix(x0, x1, frac);
+
+  if (abs(xCoeff) < 0.0001) return vec3(0.0, 0.0, -1.0);
+  float rLon = (x / xCoeff) * RAD_TO_DEG;
+  if (abs(rLon) > 180.0) return vec3(0.0, 0.0, -1.0);
+  return vec3(latDeg, rLon, 1.0);
+}
+
+vec3 inverseAzimuthalEquidistant(float x, float y) {
+  float rho = sqrt(x * x + y * y);
+  if (rho > AZIMUTHAL_CLIP_ANGLE_RAD) return vec3(0.0, 0.0, -1.0);
+  if (rho < 0.0001) return vec3(0.0, 0.0, 1.0);
+
+  float c = rho;
+  float sinC = sin(c);
+  float cosC = cos(c);
+  float rLat = asin(clamp(y * sinC / rho, -1.0, 1.0)) * RAD_TO_DEG;
+  float rLon = atan(x * sinC, rho * cosC) * RAD_TO_DEG;
+  return vec3(rLat, rLon, 1.0);
+}
+
+vec3 inverseAzimuthalHybrid(float x, float y) {
+  float rho = sqrt(x * x + y * y);
+  if (rho > AZIMUTHAL_CLIP_ANGLE_RAD) return vec3(0.0, 0.0, -1.0);
+  if (rho < 0.0001) return vec3(0.0, 0.0, 1.0);
+
+  // Newton-Raphson: solve mix(rhoEA(c), rhoED(c), blend(c)) = rho for c
+  float c = rho;
+  for (int iter = 0; iter < 8; iter++) {
+    float sinC = sin(c);
+    float cosC = cos(c);
+    float rhoEA = sqrt(max(0.0, 2.0 - 2.0 * clamp(cosC, -1.0, 1.0)));
+    float rhoED = c;
+    float blend = getAzimuthalEffectiveBlend(
+      AZIMUTHAL_HYBRID_BLEND, AZIMUTHAL_HYBRID_RIM_BLEND,
+      AZIMUTHAL_HYBRID_FAR_BLEND, c
+    );
+    float f = mix(rhoEA, rhoED, blend) - rho;
+    if (abs(f) < 0.0001) break;
+    float drhoEA = (rhoEA > 0.0001) ? sinC / rhoEA : 1.0;
+    float df = mix(drhoEA, 1.0, blend);
+    if (abs(df) < 0.0001) break;
+    c -= f / df;
+    c = max(0.0001, c);
+  }
+
+  if (c > AZIMUTHAL_CLIP_ANGLE_RAD) return vec3(0.0, 0.0, -1.0);
+  float sinC = sin(c);
+  float cosC = cos(c);
+  float rLat = asin(clamp(y * sinC / rho, -1.0, 1.0)) * RAD_TO_DEG;
+  float rLon = atan(x * sinC, rho * cosC) * RAD_TO_DEG;
+
+  // Round-trip validation: forward-project the result and verify it matches.
+  // The blended forward mapping is non-monotonic near the clip boundary,
+  // so the Newton-Raphson solver can converge to ghost solutions.
+  vec3 fwd = projectAzimuthalHybrid(rLat, rLon, 0.0, 0.0);
+  float errSq = (fwd.x - x) * (fwd.x - x) + (fwd.y - y) * (fwd.y - y);
+  if (errSq > 0.001) return vec3(0.0, 0.0, -1.0);
+
+  return vec3(rLat, rLon, 1.0);
+}
+
+vec3 inverseProjectLatLon(float x, float y, int projType) {
+  if (projType == PROJ_EQUIRECTANGULAR) return inverseEquirectangular(x, y);
+  if (projType == PROJ_MERCATOR) return inverseMercator(x, y);
+  if (projType == PROJ_ROBINSON) return inverseRobinson(x, y);
+  if (projType == PROJ_MOLLWEIDE) return inverseMollweide(x, y);
+  if (projType == PROJ_CYLINDRICAL_EQUAL_AREA) return inverseCylindricalEqualArea(x, y);
+  if (projType == PROJ_AZIMUTHAL_EQUIDISTANT) return inverseAzimuthalEquidistant(x, y);
+  if (projType == PROJ_AZIMUTHAL_HYBRID) return inverseAzimuthalHybrid(x, y);
+  return vec3(0.0, 0.0, -1.0);
+}
 
 uniform sampler2D maskTexture;
 uniform float opacity;
@@ -326,22 +491,23 @@ uniform int projectionType;
 uniform float centerLon;
 uniform float centerLat;
 
-varying vec2 vUv;
+varying vec2 vProjectedCoord;
 
 void main() {
-  if (projectionType == PROJ_MERCATOR) {
-    float lat = vUv.y * 180.0 - 90.0;
-    float lon = vUv.x * 360.0 - 180.0;
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
-    if (abs(rotated.x) > MERCATOR_LAT_LIMIT) {
-      discard;
-    }
-  }
+  vec3 result = inverseProjectLatLon(vProjectedCoord.x, vProjectedCoord.y, projectionType);
+  if (result.z < 0.0) discard;
 
-  vec4 texColor = texture2D(maskTexture, vUv);
-  if (texColor.a < 0.01) {
-    discard;
-  }
+  vec2 geo = unrotateCoords(result.x, result.y, centerLon, centerLat);
+
+  // Normalize longitude to [-180, 180]
+  float lon = mod(geo.y + 180.0, 360.0) - 180.0;
+
+  // Convert to equirectangular texture UV
+  float u = (lon + 180.0) / 360.0;
+  float v = (geo.x + 90.0) / 180.0;
+
+  vec4 texColor = texture2D(maskTexture, vec2(u, v));
+  if (texColor.a < 0.01) discard;
   gl_FragColor = vec4(texColor.rgb, texColor.a * opacity);
 }
 `;
@@ -354,8 +520,9 @@ class GpuProjectedMaskRenderer {
 
   /**
    * Create a mask mesh.
-   * For globe mode: GPU-projected geometry for instant center changes.
-   * For flat projections: d3-projected geometry with proper clipping.
+   * Globe: uses GPU forward-projected geometry with latLon attributes.
+   * Flat:  uses a quad with inverse-projection fragment shader.
+   * Both paths support instant center changes via uniform updates only.
    */
   static async render(
     mode: TLandSeaMaskMode,
@@ -373,27 +540,23 @@ class GpuProjectedMaskRenderer {
     let material: THREE.ShaderMaterial;
 
     if (projectionHelper.isFlat) {
-      // For flat projections, use d3 to project geometry with proper clipping
-      geometry = this.createD3ProjectedGeometry(projectionHelper, mode);
-      material = this.createFlatMaterial(
+      geometry = this.createFlatQuadGeometry(mode);
+      material = this.createFlatInverseMaterial(
         texture,
         mode,
         getProjectionTypeFromMode(projectionHelper.type),
         projectionHelper.center
       );
     } else {
-      // For globe, use GPU projection
       geometry = this.createGlobeGeometry();
-      material = this.createGlobeMaterial(texture, mode, projectionHelper);
+      material = this.createGlobeMaterial(texture, mode);
     }
 
     const mesh = new THREE.Mesh(geometry, material);
     mesh.name = "mask";
-    mesh.userData.maskMode = mode; // Store mode for updateProjection
+    mesh.userData.maskMode = mode;
 
-    if (!projectionHelper.isFlat) {
-      mesh.frustumCulled = false;
-    }
+    mesh.frustumCulled = false;
     const globeMode = isGlobeMaskMode(mode);
     mesh.renderOrder = globeMode ? -1 : 10;
 
@@ -402,33 +565,15 @@ class GpuProjectedMaskRenderer {
 
   /**
    * Update projection on an existing mask mesh.
-   * For globe: updates uniforms (fast).
-   * For flat: rebuilds geometry (required for proper clipping).
+   * For both globe and flat projections, this only updates uniforms (fast).
    */
   static updateProjection(
     mesh: THREE.Mesh,
     projectionHelper: ProjectionHelper
   ): void {
     const material = mesh.material as THREE.ShaderMaterial;
-
-    if (projectionHelper.isFlat) {
-      // For flat projections, rebuild geometry with new projection
-      const oldGeometry = mesh.geometry;
-      const mode = mesh.userData.maskMode as TLandSeaMaskMode;
-      const newGeometry = this.createD3ProjectedGeometry(
-        projectionHelper,
-        mode
-      );
-      mesh.geometry = newGeometry;
-      this.applyProjectionUniforms(material, projectionHelper);
-      // Signal Three.js that the geometry has changed
-      mesh.geometry.computeBoundingSphere();
-      mesh.geometry.computeBoundingBox();
-      oldGeometry.dispose();
-    } else {
-      this.applyProjectionUniforms(material, projectionHelper);
-      material.needsUpdate = true;
-    }
+    this.applyProjectionUniforms(material, projectionHelper);
+    material.needsUpdate = true;
   }
 
   private static applyProjectionUniforms(
@@ -454,407 +599,77 @@ class GpuProjectedMaskRenderer {
   }
 
   /**
-   * Calculate angular distance from projection center to a point.
-   * Uses the spherical law of cosines.
+   * Create a quad covering the flat projection's coordinate space.
+   * The fragment shader handles clipping to the actual projection boundary.
    */
-  private static angularDistanceFromCenter(
-    lat: number,
-    lon: number,
-    centerLat: number,
-    centerLon: number
-  ): number {
-    const toRad = Math.PI / 180;
-    const lat1 = centerLat * toRad;
-    const lat2 = lat * toRad;
-    const dLon = (lon - centerLon) * toRad;
-
-    // Spherical law of cosines
-    const cosAngle =
-      Math.sin(lat1) * Math.sin(lat2) +
-      Math.cos(lat1) * Math.cos(lat2) * Math.cos(dLon);
-
-    // Clamp to [-1, 1] to handle floating point errors
-    const clampedCos = Math.max(-1, Math.min(1, cosAngle));
-    return Math.acos(clampedCos) * (180 / Math.PI);
-  }
-
-  private static generateVerticesAndUVs(
-    projectionHelper: ProjectionHelper,
-    latSegments: number,
-    lonSegments: number,
+  private static createFlatQuadGeometry(
     mode?: TLandSeaMaskMode
-  ) {
+  ): THREE.BufferGeometry {
     const isBackground = mode ? isGlobeMaskMode(mode) : true;
     const zOffset = isBackground ? -0.01 : 0.01;
-    const vertices: number[] = [];
-    const uvs: number[] = [];
-    const angularDistances: number[] = []; // Track angular distance from center for azimuthal clipping
-    const isMercator = projectionHelper.type === PROJECTION_TYPES.MERCATOR;
-    const isAzimuthal = isAzimuthalProjectionType(projectionHelper.type);
+    const extent = 4.0; // generous extent covering all projection types
 
-    const centerLat = projectionHelper.center.lat;
-    const centerLon = projectionHelper.center.lon;
+    const vertices = new Float32Array([
+      -extent,
+      -extent,
+      zOffset,
+      extent,
+      -extent,
+      zOffset,
+      extent,
+      extent,
+      zOffset,
+      -extent,
+      extent,
+      zOffset,
+    ]);
 
-    // Generate vertices using the helper projection (matches data orientation).
-    // For Mercator, clamp projection latitude to avoid infinity, then discard
-    // outside the valid band in the fragment shader.
-    for (let latIdx = 0; latIdx <= latSegments; latIdx++) {
-      const latRaw = 90 - (latIdx / latSegments) * 180;
-      let latProjected = latRaw;
-      if (isAzimuthal && Math.abs(latProjected) >= 90) {
-        // Avoid antipode singularity in azimuthal projections.
-        latProjected = Math.sign(latProjected) * 89.999;
-      }
-      if (isMercator) {
-        latProjected = Math.max(
-          -MERCATOR_LAT_LIMIT,
-          Math.min(MERCATOR_LAT_LIMIT, latProjected)
-        );
-      }
-      const v = (90 - latRaw) / 180; // top (90) -> 0, bottom (-90) -> 1
-
-      for (let lonIdx = 0; lonIdx <= lonSegments; lonIdx++) {
-        const lon = (lonIdx / lonSegments) * 360 - 180;
-        const u = lonIdx / lonSegments;
-        const [x, y, z] = projectionHelper.project(latProjected, lon, 1);
-        vertices.push(x, y, z + zOffset);
-        uvs.push(u, 1 - v);
-
-        // For azimuthal projection, track angular distance for clipping
-        if (isAzimuthal) {
-          const angularDist = this.angularDistanceFromCenter(
-            latRaw,
-            lon,
-            centerLat,
-            centerLon
-          );
-          angularDistances.push(angularDist);
-        }
-      }
-    }
-    return { vertices, uvs, angularDistances, isAzimuthal };
-  }
-
-  private static getVertexPosition(vertices: number[], index: number) {
-    return {
-      x: vertices[index * 3],
-      y: vertices[index * 3 + 1],
-    };
-  }
-
-  // Calculate maximum distance between triangle vertices
-  private static calculateMaxTriangleDistance(
-    vertices: number[],
-    i1: number,
-    i2: number,
-    i3: number
-  ) {
-    const v1 = this.getVertexPosition(vertices, i1);
-    const v2 = this.getVertexPosition(vertices, i2);
-    const v3 = this.getVertexPosition(vertices, i3);
-
-    const maxDx = Math.max(
-      Math.abs(v1.x - v2.x),
-      Math.abs(v1.x - v3.x),
-      Math.abs(v2.x - v3.x)
-    );
-
-    const maxDy = Math.max(
-      Math.abs(v1.y - v2.y),
-      Math.abs(v1.y - v3.y),
-      Math.abs(v2.y - v3.y)
-    );
-
-    return { maxDx, maxDy };
-  }
-
-  // Check if triangle should be included (doesn't span projection cut)
-  private static shouldIncludeTriangle(
-    vertices: number[],
-    i1: number,
-    i2: number,
-    i3: number,
-    threshold: number,
-    straddleMultiplier: number = 0.5
-  ): boolean {
-    const { maxDx, maxDy } = this.calculateMaxTriangleDistance(
-      vertices,
-      i1,
-      i2,
-      i3
-    );
-
-    // Primary check: no edge should span more than threshold
-    if (maxDx >= threshold || maxDy >= threshold) {
-      return false;
-    }
-
-    // Secondary check for elliptical projections (Mollweide):
-    // Triangles that straddle x=0 (the center longitude) with significant
-    // span should be clipped. This catches triangles where vertices are on
-    // opposite sides of the projection center but individual edges are short.
-    const v1 = this.getVertexPosition(vertices, i1);
-    const v2 = this.getVertexPosition(vertices, i2);
-    const v3 = this.getVertexPosition(vertices, i3);
-
-    let minX = v1.x;
-    let maxX = v1.x;
-
-    if (v2.x < minX) {
-      minX = v2.x;
-    }
-    if (v2.x > maxX) {
-      maxX = v2.x;
-    }
-
-    if (v3.x < minX) {
-      minX = v3.x;
-    }
-    if (v3.x > maxX) {
-      maxX = v3.x;
-    }
-    // If triangle straddles x=0 and total x-span is significant, clip it
-    // The straddleMultiplier varies by projection type:
-    // - Mollweide uses 0.12 (aggressive) due to its elliptical shape causing polar bands
-    // - Other projections use 0.5 (less aggressive) to avoid over-clipping
-    const straddlesCenter = minX < 0 && maxX > 0;
-    const totalXSpan = maxX - minX;
-    if (straddlesCenter && totalXSpan > threshold * straddleMultiplier) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Check if any vertex in a triangle exceeds the azimuthal clip angle.
-   */
-  private static isTriangleWithinClipAngle(
-    angularDistances: number[],
-    i1: number,
-    i2: number,
-    i3: number,
-    clipAngle: number
-  ): boolean {
-    return (
-      angularDistances[i1] < clipAngle &&
-      angularDistances[i2] < clipAngle &&
-      angularDistances[i3] < clipAngle
-    );
-  }
-
-  private static isWithinClipAngle(
-    angularDistances: number[],
-    isAzimuthal: boolean,
-    idx1: number,
-    idx2: number,
-    idx3: number
-  ): boolean {
-    if (!isAzimuthal) {
-      return true;
-    }
-
-    return this.isTriangleWithinClipAngle(
-      angularDistances,
-      idx1,
-      idx2,
-      idx3,
-      AZIMUTHAL_CLIP_ANGLE
-    );
-  }
-
-  private static isValidTriangle(
-    context: TMaskContext,
-    idx1: number,
-    idx2: number,
-    idx3: number
-  ): boolean {
-    const withinClip = this.isWithinClipAngle(
-      context.angularDistances,
-      context.isAzimuthal,
-      idx1,
-      idx2,
-      idx3
-    );
-
-    if (!withinClip) {
-      return false;
-    }
-
-    return this.shouldIncludeTriangle(
-      context.vertices,
-      idx1,
-      idx2,
-      idx3,
-      context.threshold,
-      context.straddleMultiplier
-    );
-  }
-
-  /**
-   * Create geometry projected by d3 with proper antimeridian clipping.
-   */
-  private static createD3ProjectedGeometry(
-    projectionHelper: ProjectionHelper,
-    mode?: TLandSeaMaskMode
-  ): THREE.BufferGeometry {
-    const { latSegments, lonSegments } = this.GRID_RESOLUTION;
-    const { vertices, uvs, angularDistances, isAzimuthal } =
-      this.generateVerticesAndUVs(
-        projectionHelper,
-        latSegments,
-        lonSegments,
-        mode
-      );
-    const indices = this.generateD3MaskIndices(
-      vertices,
-      angularDistances,
-      isAzimuthal,
-      latSegments,
-      lonSegments,
-      projectionHelper
-    );
-    return this.createBufferGeometry(vertices, uvs, indices);
-  }
-
-  private static generateD3MaskIndices(
-    vertices: number[],
-    angularDistances: number[],
-    isAzimuthal: boolean,
-    latSegments: number,
-    lonSegments: number,
-    projectionHelper: ProjectionHelper
-  ): number[] {
-    const width = this.getProjectionWidth(projectionHelper);
-    const threshold = width * 0.4; // Triangles spanning more than 40% of width are cut
-
-    // Mollweide's elliptical shape requires aggressive straddle clipping at poles
-    const isMollweide = projectionHelper.type === PROJECTION_TYPES.MOLLWEIDE;
-    const straddleMultiplier = isMollweide ? 0.12 : 0.5;
-
-    const context: TMaskContext = {
-      vertices,
-      angularDistances,
-      isAzimuthal,
-      lonSegments,
-      threshold,
-      straddleMultiplier,
-    };
-
-    return this.collectMaskTriangleIndices(context, latSegments);
-  }
-
-  private static getQuadIndices(
-    latIdx: number,
-    lonIdx: number,
-    lonSegments: number
-  ): { a: number; b: number; c: number; d: number } {
-    const a = latIdx * (lonSegments + 1) + lonIdx;
-    const b = a + lonSegments + 1;
-    const c = a + 1;
-    const d = b + 1;
-
-    return { a, b, c, d };
-  }
-
-  private static collectMaskTriangleIndices(
-    context: TMaskContext,
-    latSegments: number
-  ): number[] {
-    const indices: number[] = [];
-
-    for (let latIdx = 0; latIdx < latSegments; latIdx++) {
-      for (let lonIdx = 0; lonIdx < context.lonSegments; lonIdx++) {
-        const { a, b, c, d } = this.getQuadIndices(
-          latIdx,
-          lonIdx,
-          context.lonSegments
-        );
-
-        if (this.isValidTriangle(context, a, b, c)) {
-          indices.push(a, b, c);
-        }
-        if (this.isValidTriangle(context, c, b, d)) {
-          indices.push(c, b, d);
-        }
-      }
-    }
-    return indices;
-  }
-
-  private static createBufferGeometry(
-    vertices: number[],
-    uvs: number[],
-    indices: number[]
-  ): THREE.BufferGeometry {
     const geometry = new THREE.BufferGeometry();
-
     geometry.setAttribute(
       "position",
       new THREE.Float32BufferAttribute(vertices, 3)
     );
-    geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2));
-    geometry.setIndex(indices);
-
+    geometry.setIndex([0, 1, 2, 0, 2, 3]);
     return geometry;
   }
 
   /**
-   * Get the approximate width of the projection in projected coordinates.
-   */
-  private static getProjectionWidth(
-    projectionHelper: ProjectionHelper
-  ): number {
-    const d3Proj = projectionHelper.getD3Projection();
-    if (d3Proj) {
-      const path = d3.geoPath(d3Proj);
-      const bounds = path.bounds({ type: "Sphere" });
-      if (bounds && bounds[0] && bounds[1]) {
-        return Math.abs(bounds[1][0] - bounds[0][0]);
-      }
-    }
-    return Math.PI * 2; // Fallback
-  }
-
-  /**
-   * Create geometry for globe projection (closed mesh that wraps around).
+   * Create globe geometry with wrapped indices and no duplicated antimeridian
+   * vertex column. The fragment shader derives UVs from sphere position, so it
+   * does not need a UV or lat/lon attribute seam.
    */
   private static createGlobeGeometry(): THREE.BufferGeometry {
     const { latSegments, lonSegments } = this.GRID_RESOLUTION;
     const geometry = new THREE.BufferGeometry();
 
     const vertices: number[] = [];
-    const uvs: number[] = [];
-    const latLonCoords: number[] = [];
     const indices: number[] = [];
 
-    // Generate vertices - for globe we need to include lon=180 for proper UV mapping
     for (let latIdx = 0; latIdx <= latSegments; latIdx++) {
-      const lat = 90 - (latIdx / latSegments) * 180; // 90 to -90
-      const v = latIdx / latSegments;
+      const lat = 90 - (latIdx / latSegments) * 180;
+      const latRad = THREE.MathUtils.degToRad(lat);
+      const cosLat = Math.cos(latRad);
+      const sinLat = Math.sin(latRad);
 
-      for (let lonIdx = 0; lonIdx <= lonSegments; lonIdx++) {
-        const lon = (lonIdx / lonSegments) * 360 - 180; // -180 to 180
-        const u = lonIdx / lonSegments;
+      for (let lonIdx = 0; lonIdx < lonSegments; lonIdx++) {
+        const lon = (lonIdx / lonSegments) * 360 - 180;
+        const lonRad = THREE.MathUtils.degToRad(lon);
 
-        // Store lat/lon for GPU projection
-        latLonCoords.push(lat, lon);
-
-        // Placeholder vertex positions (will be computed on GPU)
-        vertices.push(0, 0, 0);
-
-        // UV coordinates for texture sampling
-        uvs.push(u, 1 - v);
+        vertices.push(
+          cosLat * Math.cos(lonRad),
+          cosLat * Math.sin(lonRad),
+          sinLat
+        );
       }
     }
 
-    // Generate indices - for globe, create all triangles
     for (let latIdx = 0; latIdx < latSegments; latIdx++) {
       for (let lonIdx = 0; lonIdx < lonSegments; lonIdx++) {
-        const a = latIdx * (lonSegments + 1) + lonIdx;
-        const b = a + lonSegments + 1;
-        const c = a + 1;
-        const d = b + 1;
+        const nextLonIdx = (lonIdx + 1) % lonSegments;
+        const a = latIdx * lonSegments + lonIdx;
+        const b = (latIdx + 1) * lonSegments + lonIdx;
+        const c = latIdx * lonSegments + nextLonIdx;
+        const d = (latIdx + 1) * lonSegments + nextLonIdx;
 
         indices.push(a, b, c);
         indices.push(c, b, d);
@@ -864,11 +679,6 @@ class GpuProjectedMaskRenderer {
     geometry.setAttribute(
       "position",
       new THREE.Float32BufferAttribute(vertices, 3)
-    );
-    geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2));
-    geometry.setAttribute(
-      "latLon",
-      new THREE.Float32BufferAttribute(latLonCoords, 2)
     );
     geometry.setIndex(indices);
 
@@ -880,11 +690,8 @@ class GpuProjectedMaskRenderer {
    */
   private static createGlobeMaterial(
     texture: THREE.Texture,
-    mode: TLandSeaMaskMode,
-    projectionHelper: ProjectionHelper
+    mode: TLandSeaMaskMode
   ): THREE.ShaderMaterial {
-    const projType = getProjectionTypeFromMode(projectionHelper.type);
-    const center = projectionHelper.center;
     const globeMode = isGlobeMaskMode(mode);
 
     // For globe mode (full earth background), use smaller radius so it's behind data
@@ -894,16 +701,13 @@ class GpuProjectedMaskRenderer {
     const material = new THREE.ShaderMaterial({
       uniforms: {
         maskTexture: { value: texture },
-        projectionType: { value: projType },
-        centerLon: { value: center.lon },
-        centerLat: { value: center.lat },
         projectionRadius: { value: radius },
         opacity: { value: 1.0 },
       },
       vertexShader: gpuProjectedMaskVertexShader,
       fragmentShader: gpuProjectedMaskFragmentShader,
       transparent: true,
-      side: THREE.DoubleSide,
+      side: THREE.FrontSide,
       depthWrite: false,
       depthTest: true,
     });
@@ -912,9 +716,9 @@ class GpuProjectedMaskRenderer {
   }
 
   /**
-   * Create the shader material for d3-projected flat mask.
+   * Create the shader material for flat mask with inverse projection.
    */
-  private static createFlatMaterial(
+  private static createFlatInverseMaterial(
     texture: THREE.Texture,
     mode: TLandSeaMaskMode,
     projectionType: number,
@@ -928,12 +732,12 @@ class GpuProjectedMaskRenderer {
         centerLon: { value: center.lon },
         centerLat: { value: center.lat },
       },
-      vertexShader: flatMaskVertexShader,
-      fragmentShader: flatMaskFragmentShader,
+      vertexShader: flatInverseVertexShader,
+      fragmentShader: flatInverseFragmentShader,
       transparent: true,
       side: THREE.DoubleSide,
       depthWrite: false,
-      depthTest: true,
+      depthTest: false,
     });
 
     // Use polygon offset to prevent z-fighting
@@ -942,6 +746,17 @@ class GpuProjectedMaskRenderer {
     material.polygonOffsetUnits = isGlobeMaskMode(mode) ? 1 : -1;
 
     return material;
+  }
+
+  private static async createGlobeTexture(): Promise<THREE.Texture> {
+    const img = await ResourceCache.loadImage(albedo);
+    const { canvas, ctx, width, height } = CanvasFactory.create(
+      img.naturalWidth,
+      img.naturalHeight
+    );
+    ctx.drawImage(img, 0, 0, width, height);
+    copyAntimeridianEdge(ctx, width);
+    return configureEquirectangularTexture(new THREE.CanvasTexture(canvas));
   }
 
   private static async renderMaskedMode(
@@ -953,37 +768,36 @@ class GpuProjectedMaskRenderer {
     width: number,
     height: number
   ) {
-    // Masked modes: show only land or sea
     if (useTexture) {
       const img = await ResourceCache.loadImage(albedo);
       ctx.drawImage(img, 0, 0, width, height);
 
-      // Mask out unwanted area
       ctx.beginPath();
       path(land);
       ctx.globalCompositeOperation = config.showLand
         ? "destination-in"
         : "destination-out";
       ctx.fill();
-    } else {
-      if (config.showSea) {
-        ctx.fillStyle = MASK_COLORS.sea;
-        ctx.fillRect(0, 0, width, height);
-        if (!config.showLand) {
-          // Cut out land
-          ctx.beginPath();
-          path(land);
-          ctx.globalCompositeOperation = "destination-out";
-          ctx.fill();
-        }
-      }
-      if (config.showLand) {
-        ctx.globalCompositeOperation = "source-over";
+      return;
+    }
+
+    if (config.showSea) {
+      ctx.fillStyle = MASK_COLORS.sea;
+      ctx.fillRect(0, 0, width, height);
+      if (!config.showLand) {
         ctx.beginPath();
         path(land);
-        ctx.fillStyle = MASK_COLORS.land;
+        ctx.globalCompositeOperation = "destination-out";
         ctx.fill();
       }
+    }
+
+    if (config.showLand) {
+      ctx.globalCompositeOperation = "source-over";
+      ctx.beginPath();
+      path(land);
+      ctx.fillStyle = MASK_COLORS.land;
+      ctx.fill();
     }
   }
 
@@ -995,21 +809,19 @@ class GpuProjectedMaskRenderer {
     width: number,
     height: number
   ) {
-    // Globe modes: full earth texture or colored land/sea
     if (useTexture) {
       const img = await ResourceCache.loadImage(albedo);
       ctx.drawImage(img, 0, 0, width, height);
-    } else {
-      // Draw sea background
-      ctx.fillStyle = MASK_COLORS.sea;
-      ctx.fillRect(0, 0, width, height);
-
-      // Draw land
-      ctx.beginPath();
-      path(land);
-      ctx.fillStyle = MASK_COLORS.land;
-      ctx.fill();
+      return;
     }
+
+    ctx.fillStyle = MASK_COLORS.sea;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.beginPath();
+    path(land);
+    ctx.fillStyle = MASK_COLORS.land;
+    ctx.fill();
   }
 
   /**
@@ -1021,10 +833,13 @@ class GpuProjectedMaskRenderer {
     useTexture: boolean,
     config: TMaskConfig
   ): Promise<THREE.Texture> {
-    const { canvas, ctx, width, height } = CanvasFactory.create(4096, 2048);
-    const land = await ResourceCache.loadLandGeoJSON();
+    // Globe texture also goes through a canvas so its antimeridian columns match.
+    if (isGlobeMaskMode(mode) && useTexture) {
+      return this.createGlobeTexture();
+    }
 
-    // Create equirectangular projection for texture rendering
+    const { canvas, ctx, width, height } = CanvasFactory.create();
+    const land = await ResourceCache.loadLandGeoJSON();
     const projection = D3ProjectionFactory.createEquirectangular(width, height);
     const path = d3.geoPath(projection, ctx);
 
@@ -1042,12 +857,9 @@ class GpuProjectedMaskRenderer {
       );
     }
 
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.wrapS = THREE.ClampToEdgeWrapping;
-    texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.needsUpdate = true;
+    copyAntimeridianEdge(ctx, width);
 
-    return texture;
+    return configureEquirectangularTexture(new THREE.CanvasTexture(canvas));
   }
 }
 

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -399,7 +399,7 @@ class GpuProjectedMaskRenderer {
 
   /**
    * Create a mask mesh.
-   * Globe: uses GPU forward-projected geometry with latLon attributes.
+   * Globe: uses CPU-built sphere geometry rendered directly in globe space.
    * Flat:  uses a quad with inverse-projection fragment shader.
    * Both paths support instant center changes via uniform updates only.
    */

--- a/src/lib/projection/projectionShaders.ts
+++ b/src/lib/projection/projectionShaders.ts
@@ -35,6 +35,7 @@ export const projectionShaderFunctions = `
   #define DEG_TO_RAD 0.017453292519943295
   #define RAD_TO_DEG 57.29577951308232
   #define MERCATOR_LAT_LIMIT 85.0
+  #define CYLINDRICAL_EQUAL_AREA_SCALE 1.2792006328649603
   #define AZIMUTHAL_CLIP_ANGLE_RAD ${(AZIMUTHAL_CLIP_ANGLE * Math.PI) / 180.0}
 
   #define PROJ_GLOBE 0
@@ -221,9 +222,8 @@ export const projectionShaderFunctions = `
   // D3 uses: x = λ / k, y = sin(φ) * k where k ≈ 1.2792 (derived from default scale)
   vec3 projectCylindricalEqualArea(float lat, float lon, float centerLon, float centerLat) {
     vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
-    float k = 1.2792006328649603;  // From d3-geo-projection internal scaling
-    float x = rotated.y * DEG_TO_RAD / k;
-    float y = sin(rotated.x * DEG_TO_RAD) * k;
+    float x = rotated.y * DEG_TO_RAD / CYLINDRICAL_EQUAL_AREA_SCALE;
+    float y = sin(rotated.x * DEG_TO_RAD) * CYLINDRICAL_EQUAL_AREA_SCALE;
     return vec3(x, y, 0.0);
   }
 

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -448,4 +448,6 @@ export function updateProjectionUniforms(
   if (material.uniforms.projectionRadius) {
     material.uniforms.projectionRadius.value = radius;
   }
+  material.depthTest =
+    projectionHelper.type === PROJECTION_TYPES.NEARSIDE_PERSPECTIVE;
 }

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -23,6 +23,12 @@ bool is_nan(float v) {
 }
 `;
 
+const isEqualsEpsilon = `
+bool is_equals_epsilon(float a, float b) {
+  return abs(a - b) < abs(b) * 1e-6;
+}
+`;
+
 const posterizeGLSL = `
 float posterize(float value, float levels) {
     if (levels > 1.0) {
@@ -38,6 +44,8 @@ const textureColormapFragmentShader = `
 ${colormapShaders}
 
 ${isNaNGLSL}
+
+${isEqualsEpsilon}
 
 ${posterizeGLSL}
 
@@ -55,7 +63,7 @@ varying vec2 vUv;
 void main() {
     gl_FragColor.a = 1.0;
     float v_value = texture(data, vUv).r;
-    if (is_nan(v_value) || v_value == fillValue || v_value == missingValue || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -72,6 +80,8 @@ ${colormapShaders}
 
 ${isNaNGLSL}
 
+${isEqualsEpsilon}
+
 ${posterizeGLSL}
 
 varying float v_value;
@@ -84,7 +94,7 @@ uniform float posterizeLevels;
 uniform float hideBelowValue;
 
 void main() {
-    if (is_nan(v_value) || v_value == fillValue || v_value == missingValue || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -110,6 +120,8 @@ ${colormapShaders}
 
 ${isNaNGLSL}
 
+${isEqualsEpsilon}
+
 ${posterizeGLSL}
 
 varying float v_value;
@@ -133,7 +145,7 @@ void main() {
     if (falloff < 0.01) discard; // Optional: discard transparent fragments
 
 
-    if (is_nan(v_value) || v_value == fillValue || v_value == missingValue || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -18,14 +18,11 @@ import {
 } from "./colormapShaders";
 
 const isNaNGLSL = `
-bool is_nan(float v) {
-    return v != v;
-}
-`;
-
-const isEqualsEpsilon = `
-bool is_equals_epsilon(float a, float b) {
-  return abs(a - b) < abs(b) * 1e-6;
+bool is_nan(float val) {
+    uint bits = floatBitsToUint(val);
+    // exponent all 1s (0x7F800000) AND non-zero mantissa = NaN
+    // exponent all 1s AND zero mantissa = Infinity (not NaN)
+    return (bits & 0x7F800000u) == 0x7F800000u && (bits & 0x007FFFFFu) != 0u;
 }
 `;
 
@@ -45,14 +42,10 @@ ${colormapShaders}
 
 ${isNaNGLSL}
 
-${isEqualsEpsilon}
-
 ${posterizeGLSL}
 
 uniform float addOffset;
 uniform float scaleFactor;
-uniform float missingValue;
-uniform float fillValue;
 uniform int colormap;
 uniform float posterizeLevels;
 uniform float hideBelowValue;
@@ -63,7 +56,7 @@ varying vec2 vUv;
 void main() {
     gl_FragColor.a = 1.0;
     float v_value = texture(data, vUv).r;
-    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -80,21 +73,17 @@ ${colormapShaders}
 
 ${isNaNGLSL}
 
-${isEqualsEpsilon}
-
 ${posterizeGLSL}
 
 varying float v_value;
 uniform float addOffset;
 uniform float scaleFactor;
 uniform int colormap;
-uniform float missingValue;
-uniform float fillValue;
 uniform float posterizeLevels;
 uniform float hideBelowValue;
 
 void main() {
-    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -120,16 +109,12 @@ ${colormapShaders}
 
 ${isNaNGLSL}
 
-${isEqualsEpsilon}
-
 ${posterizeGLSL}
 
 varying float v_value;
 uniform float addOffset;
 uniform float scaleFactor;
 uniform int colormap;
-uniform float fillValue;
-uniform float missingValue;
 uniform float posterizeLevels;
 uniform float hideBelowValue;
 
@@ -145,7 +130,7 @@ void main() {
     if (falloff < 0.01) discard; // Optional: discard transparent fragments
 
 
-    if (is_nan(v_value) || is_equals_epsilon(v_value, fillValue) || is_equals_epsilon(v_value, missingValue) || v_value <= hideBelowValue) {
+    if (is_nan(v_value) || v_value <= hideBelowValue) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -355,8 +340,6 @@ export function makeGpuProjectedTextureMaterial(
       addOffset: { value: addOffset },
       scaleFactor: { value: scaleFactor },
       colormap: { value: availableColormaps[colormap] },
-      fillValue: { value: Number.POSITIVE_INFINITY },
-      missingValue: { value: Number.POSITIVE_INFINITY },
       posterizeLevels: { value: 0.0 },
       hideBelowValue: { value: -1e38 },
       data: { value: texture },
@@ -390,8 +373,6 @@ export function makeGpuProjectedMeshMaterial(
       scaleFactor: { value: scaleFactor },
       pointSize: { value: 0.0 },
       colormap: { value: availableColormaps[colormap] },
-      fillValue: { value: Number.POSITIVE_INFINITY },
-      missingValue: { value: Number.POSITIVE_INFINITY },
       posterizeLevels: { value: 0.0 },
       hideBelowValue: { value: -1e38 },
       // Projection uniforms
@@ -425,8 +406,6 @@ export function makeGpuProjectedPointMaterial(
       basePointSize: { value: 5.0 },
       minPointSize: { value: 1.0 },
       maxPointSize: { value: 10.0 },
-      fillValue: { value: Number.POSITIVE_INFINITY },
-      missingValue: { value: Number.POSITIVE_INFINITY },
       posterizeLevels: { value: 0.0 },
       hideBelowValue: { value: -1e38 },
       colormap: { value: availableColormaps[colormap] },

--- a/src/ui/grids/Curvilinear.vue
+++ b/src/ui/grids/Curvilinear.vue
@@ -14,9 +14,10 @@ import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts"
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import {
   castDataVarToFloat32,
+  createMissingOrFillPredicate,
   getDataBounds,
   getLatLonData,
-  createMissingOrFillPredicate,
+  mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import {
   makeGpuProjectedMeshMaterial,
@@ -641,14 +642,6 @@ function setHoverData(
   );
 }
 
-function applyMissingFillUniforms(fillValue: number, missingValue: number) {
-  for (let mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    material.uniforms.missingValue.value = missingValue;
-    material.uniforms.fillValue.value = fillValue;
-  }
-}
-
 async function renderGridAndHover(
   datavar: zarr.Array<zarr.DataType, zarr.FetchStore>,
   rawData: Float32Array,
@@ -689,13 +682,13 @@ async function fetchAndRenderData(
     false
   );
 
-  const rawData = castDataVarToFloat32(
+  let rawData = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
   );
   const { min, max, missingValue, fillValue } = getDataBounds(datavar, rawData);
+  rawData = mapMissingAndFillToNaN(rawData, missingValue, fillValue);
 
   await renderGridAndHover(datavar, rawData, fillValue, missingValue);
-  applyMissingFillUniforms(fillValue, missingValue);
 
   const dimInfo = await getDimensionValues(dimensionRanges, indices);
 

--- a/src/ui/grids/GaussianReduced.vue
+++ b/src/ui/grids/GaussianReduced.vue
@@ -16,6 +16,7 @@ import {
   castDataVarToFloat32,
   getDataBounds,
   getLatLonData,
+  mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
@@ -454,6 +455,7 @@ async function fetchAndRenderData(
   const longitudesData = longitudes!.data as Float64Array;
 
   let { min, max, missingValue, fillValue } = getDataBounds(datavar, rawData);
+  rawData = mapMissingAndFillToNaN(rawData, missingValue, fillValue);
 
   buildGaussianReducedGeometry(latitudesData, longitudesData, rawData);
 
@@ -466,12 +468,6 @@ async function fetchAndRenderData(
 
   // Set projection uniforms on all meshes after grid creation
   updateMeshProjectionUniforms();
-
-  for (let mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    material.uniforms.missingValue.value = missingValue;
-    material.uniforms.fillValue.value = fillValue;
-  }
 
   const dimInfo = await getDimensionValues(dimensionRanges, indices);
   updateHistogram(rawData, min, max, missingValue, fillValue);

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -13,7 +13,11 @@ import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
-import { castDataVarToFloat32, getDataBounds } from "@/lib/data/zarrUtils.ts";
+import {
+  castDataVarToFloat32,
+  getDataBounds,
+  mapMissingAndFillToNaN,
+} from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
   getColormapScaleOffset,
@@ -372,6 +376,8 @@ async function getHealpixData(
   } else if (isNaN(fillValue)) {
     fillValue = HEALPIX_UNSEEN;
   }
+  mapMissingAndFillToNaN(dataSlice, missingValue, fillValue);
+  ({ min, max } = getDataBounds(datavar, dataSlice));
 
   // Filter out missing and fill values before building histogram
   return {
@@ -656,8 +662,6 @@ async function processHealpixChunks(
       dataMax = dataMax < texData.max ? texData.max : dataMax;
 
       const material = mainMeshes[ipix].material as THREE.ShaderMaterial;
-      material.uniforms.missingValue.value = texData.missingValue;
-      material.uniforms.fillValue.value = texData.fillValue;
       material.uniforms.data.value.dispose();
       material.uniforms.data.value = texData.texture;
 
@@ -726,6 +730,13 @@ async function fetchAndRenderData(
   hoverData.value = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
   );
+  let { missingValue, fillValue } = getDataBounds(datavar, hoverData.value);
+  if (isNaN(missingValue)) {
+    missingValue = HEALPIX_UNSEEN;
+  } else if (isNaN(fillValue)) {
+    fillValue = HEALPIX_UNSEEN;
+  }
+  mapMissingAndFillToNaN(hoverData.value, missingValue, fillValue);
   if (cellCoord) {
     const cellIndexMap = new Map<number, number>();
     for (let index = 0; index < cellCoord.length; index++) {

--- a/src/ui/grids/Irregular.vue
+++ b/src/ui/grids/Irregular.vue
@@ -17,6 +17,7 @@ import {
   castDataVarToFloat32,
   getDataBounds,
   getLatLonData,
+  mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import {
   makeGpuProjectedPointMaterial,
@@ -456,16 +457,11 @@ async function fetchAndRenderData(
   );
 
   let { min, max, fillValue, missingValue } = getDataBounds(datavar, rawData);
+  rawData = mapMissingAndFillToNaN(rawData, missingValue, fillValue);
   getGrid(latitudes, longitudes!, rawData);
 
   // Update hover lookup
   updateHoverLookup(rawData, latitudes, longitudes!, fillValue, missingValue);
-
-  for (const p of points) {
-    const material = p.material as THREE.ShaderMaterial;
-    material.uniforms.fillValue.value = fillValue;
-    material.uniforms.missingValue.value = missingValue;
-  }
 
   const dimInfo = await getDimensionValues(dimensionRanges, indices);
   updateHistogram(rawData, min, max, missingValue, fillValue);

--- a/src/ui/grids/IrregularDelaunay.vue
+++ b/src/ui/grids/IrregularDelaunay.vue
@@ -18,6 +18,7 @@ import {
   castDataVarToFloat32,
   getDataBounds,
   getLatLonData,
+  mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import {
   PROJECTION_TYPES,
@@ -292,9 +293,7 @@ function cleanupMeshes() {
 function createMeshBatch(
   batchPositions: Float32Array,
   batchLatLon: Float32Array,
-  batchDataValues: Float32Array,
-  fillValue: number,
-  missingValue: number
+  batchDataValues: Float32Array
 ) {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute(
@@ -310,10 +309,6 @@ function createMeshBatch(
 
   const mesh = new THREE.Mesh(geometry, colormapMaterial.value);
   mesh.frustumCulled = false;
-
-  const material = mesh.material as THREE.ShaderMaterial;
-  material.uniforms.fillValue.value = fillValue;
-  material.uniforms.missingValue.value = missingValue;
 
   meshes.push(mesh);
   getScene()?.add(mesh);
@@ -356,33 +351,23 @@ function shouldFlipTriangle(
 }
 
 /**
- * Check if a value is a fill or missing value.
+ * Check if a value is invalid for interpolation.
  */
-function isInvalidValue(
-  value: number,
-  fillValue: number,
-  missingValue: number
-): boolean {
-  return value === fillValue || value === missingValue || !isFinite(value);
+function isInvalidValue(value: number): boolean {
+  return !Number.isFinite(value);
 }
 
 /**
  * Compute triangle average using only valid vertices.
- * Returns missingValue if all vertices are invalid.
+ * Returns NaN if all vertices are invalid.
  */
-function computeTriangleAverage(
-  v0: number,
-  v1: number,
-  v2: number,
-  fillValue: number,
-  missingValue: number
-): number {
-  const valid0 = !isInvalidValue(v0, fillValue, missingValue);
-  const valid1 = !isInvalidValue(v1, fillValue, missingValue);
-  const valid2 = !isInvalidValue(v2, fillValue, missingValue);
+function computeTriangleAverage(v0: number, v1: number, v2: number): number {
+  const valid0 = !isInvalidValue(v0);
+  const valid1 = !isInvalidValue(v1);
+  const valid2 = !isInvalidValue(v2);
 
   if (!valid0 && !valid1 && !valid2) {
-    return missingValue;
+    return NaN;
   }
 
   let sum = 0;
@@ -408,9 +393,7 @@ function computeTriangleAverage(
 function getTriangleIndicesAndAverage(
   triangleOffset: number,
   triangleIndices: Uint32Array,
-  data: Float32Array,
-  fillValue: number,
-  missingValue: number
+  data: Float32Array
 ): { i0: number; i1: number; i2: number; avgValue: number } {
   const triIdx = triangleOffset * 3;
   const i0 = triangleIndices[triIdx];
@@ -421,7 +404,7 @@ function getTriangleIndicesAndAverage(
   const v1 = data[i1];
   const v2 = data[i2];
 
-  const avgValue = computeTriangleAverage(v0, v1, v2, fillValue, missingValue);
+  const avgValue = computeTriangleAverage(v0, v1, v2);
 
   return { i0, i1, i2, avgValue };
 }
@@ -452,16 +435,12 @@ function processTriangle(
   batchStart: number,
   triangleIndices: Uint32Array,
   src: { pos: Float32Array; ll: Float32Array; data: Float32Array },
-  dst: { pos: Float32Array; ll: Float32Array; data: Float32Array },
-  fillValue: number,
-  missingValue: number
+  dst: { pos: Float32Array; ll: Float32Array; data: Float32Array }
 ) {
   let { i0, i1, i2, avgValue } = getTriangleIndicesAndAverage(
     batchStart + t,
     triangleIndices,
-    src.data,
-    fillValue,
-    missingValue
+    src.data
   );
 
   const needsFlip = shouldFlipTriangle(
@@ -497,22 +476,12 @@ function populateBatchArrays(
   data: Float32Array,
   batchPositions: Float32Array,
   batchLatLon: Float32Array,
-  batchDataValues: Float32Array,
-  fillValue: number,
-  missingValue: number
+  batchDataValues: Float32Array
 ) {
   const src = { pos: positions, ll: latLonValues, data };
   const dst = { pos: batchPositions, ll: batchLatLon, data: batchDataValues };
   for (let t = 0; t < batchTriangleCount; t++) {
-    processTriangle(
-      t,
-      batchStart,
-      triangleIndices,
-      src,
-      dst,
-      fillValue,
-      missingValue
-    );
+    processTriangle(t, batchStart, triangleIndices, src, dst);
   }
 }
 
@@ -552,9 +521,7 @@ function createBatchedMeshes(
   positions: Float32Array,
   latLonValues: Float32Array,
   data: Float32Array,
-  triangleIndices: Uint32Array,
-  fillValue: number,
-  missingValue: number
+  triangleIndices: Uint32Array
 ) {
   const numTriangles = triangleIndices.length / 3;
 
@@ -580,18 +547,10 @@ function createBatchedMeshes(
       data,
       batchPositions,
       batchLatLon,
-      batchDataValues,
-      fillValue,
-      missingValue
+      batchDataValues
     );
 
-    createMeshBatch(
-      batchPositions,
-      batchLatLon,
-      batchDataValues,
-      fillValue,
-      missingValue
-    );
+    createMeshBatch(batchPositions, batchLatLon, batchDataValues);
   }
 }
 
@@ -602,9 +561,7 @@ function buildMeshes(
   latitudes: Float32Array,
   longitudes: Float32Array,
   data: Float32Array,
-  triangleIndices: Uint32Array,
-  fillValue: number,
-  missingValue: number
+  triangleIndices: Uint32Array
 ) {
   const N = latitudes.length;
   const positions = new Float32Array(N * 3);
@@ -612,14 +569,7 @@ function buildMeshes(
 
   projectCoordinates(latitudes, longitudes, positions, latLonValues);
   cleanupMeshes();
-  createBatchedMeshes(
-    positions,
-    latLonValues,
-    data,
-    triangleIndices,
-    fillValue,
-    missingValue
-  );
+  createBatchedMeshes(positions, latLonValues, data, triangleIndices);
   updateMeshProjectionUniforms();
   redraw();
 }
@@ -629,9 +579,7 @@ function buildMeshes(
  */
 function updateMeshDataValues(
   data: Float32Array,
-  triangleIndices: Uint32Array,
-  fillValue: number,
-  missingValue: number
+  triangleIndices: Uint32Array
 ) {
   let triOffset = 0;
 
@@ -645,9 +593,7 @@ function updateMeshDataValues(
       const { avgValue } = getTriangleIndicesAndAverage(
         triOffset + t,
         triangleIndices,
-        data,
-        fillValue,
-        missingValue
+        data
       );
 
       const vertBase = t * 3;
@@ -656,10 +602,6 @@ function updateMeshDataValues(
       dataAttr.array[vertBase + 2] = avgValue;
     }
     dataAttr.needsUpdate = true;
-
-    const material = mesh.material as THREE.ShaderMaterial;
-    material.uniforms.fillValue.value = fillValue;
-    material.uniforms.missingValue.value = missingValue;
 
     triOffset += triCount;
   }
@@ -670,9 +612,7 @@ function updateMeshDataValues(
 function getGrid(
   latitudesVar: zarr.Chunk<zarr.DataType>,
   longitudesVar: zarr.Chunk<zarr.DataType>,
-  data: Float32Array,
-  fillValue: number,
-  missingValue: number
+  data: Float32Array
 ) {
   const N = data.length;
   const { latitudes, longitudes } = reconcileCoordinates(
@@ -690,17 +630,10 @@ function getGrid(
   }
 
   if (needsRetriangulation || meshes.length === 0) {
-    buildMeshes(
-      latitudes,
-      longitudes,
-      data,
-      cachedTriangleIndices!,
-      fillValue,
-      missingValue
-    );
+    buildMeshes(latitudes, longitudes, data, cachedTriangleIndices!);
   } else {
     // Just update data values if geometry is the same
-    updateMeshDataValues(data, cachedTriangleIndices!, fillValue, missingValue);
+    updateMeshDataValues(data, cachedTriangleIndices!);
   }
 }
 
@@ -801,7 +734,8 @@ async function fetchAndRenderData(
   );
 
   let { min, max, fillValue, missingValue } = getDataBounds(datavar, rawData);
-  getGrid(latitudes, longitudes!, rawData, fillValue, missingValue);
+  rawData = mapMissingAndFillToNaN(rawData, missingValue, fillValue);
+  getGrid(latitudes, longitudes!, rawData);
 
   updateHoverLookup(rawData, latitudes, longitudes!, fillValue, missingValue);
 

--- a/src/ui/grids/Regular.vue
+++ b/src/ui/grids/Regular.vue
@@ -17,6 +17,7 @@ import {
   getDataBounds,
   isLatitudeName,
   isLongitudeName,
+  mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
@@ -638,13 +639,14 @@ async function fetchAndRenderData(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
   );
 
+  const { min, max, missingValue, fillValue } = getDataBounds(datavar, rawData);
+  rawData = mapMissingAndFillToNaN(rawData, missingValue, fillValue);
+
   const material = makeMaterial(rawData);
 
   // Set initial projection uniforms
   const helper = projectionHelper.value;
   updateProjectionUniforms(material, helper);
-
-  const { min, max, missingValue, fillValue } = getDataBounds(datavar, rawData);
 
   // Update hover lookup
   const samples = await buildHoverSamples(rawData);
@@ -654,9 +656,6 @@ async function fetchAndRenderData(
     missingValue
   );
 
-  // Set missing/fill values as uniforms for the shader
-  material.uniforms.missingValue.value = missingValue;
-  material.uniforms.fillValue.value = fillValue;
   updateHistogram(rawData, min, max, missingValue, fillValue);
 
   for (const mesh of meshes) {

--- a/src/ui/grids/Triangular.vue
+++ b/src/ui/grids/Triangular.vue
@@ -12,7 +12,11 @@ import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
-import { castDataVarToFloat32, getDataBounds } from "@/lib/data/zarrUtils.ts";
+import {
+  castDataVarToFloat32,
+  getDataBounds,
+  mapMissingAndFillToNaN,
+} from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
   makeGpuProjectedMeshMaterial,
@@ -352,6 +356,7 @@ function data2valueBuffer(
     datavar,
     plotdata
   );
+  mapMissingAndFillToNaN(plotdata, missingValue, fillValue);
   const dataValues = new Float32Array(ncells * 3);
 
   for (let i = 0; i < ncells; i++) {
@@ -363,6 +368,7 @@ function data2valueBuffer(
   }
   return {
     dataValues: dataValues,
+    plotData: plotdata,
     dataMin: min,
     dataMax: max,
     missingValue,
@@ -385,6 +391,7 @@ async function getDimensionValues(
 
 function distributeDataToMeshes(dataBuffer: {
   dataValues: Float32Array;
+  plotData: Float32Array;
   dataMin: number;
   dataMax: number;
   missingValue: number;
@@ -399,9 +406,6 @@ function distributeDataToMeshes(dataBuffer: {
       "data_value",
       new THREE.BufferAttribute(meshData, 1)
     );
-    const material = mesh.material as THREE.ShaderMaterial;
-    material.uniforms.missingValue.value = dataBuffer.missingValue;
-    material.uniforms.fillValue.value = dataBuffer.fillValue;
     offset += nVerts;
   }
 }
@@ -445,12 +449,11 @@ async function fetchAndRenderData(
   distributeDataToMeshes(dataBuffer);
 
   // Update hover lookup
-  const rawPlotData = castDataVarToFloat32(rawData.data);
   if (hoverTriangleVertices.value) {
     const hoverIndex = buildTriangleHoverIndex(
       hoverTriangleVertices.value,
       rawData.shape[0],
-      rawPlotData
+      dataBuffer.plotData
     );
     setHoverLookupFromIndex(
       hoverIndex,

--- a/src/ui/grids/composables/useGridOverlays.ts
+++ b/src/ui/grids/composables/useGridOverlays.ts
@@ -102,7 +102,7 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
       });
       coast = new THREE.LineSegments(geometry, material);
       coast.name = "coastlines";
-      coast.renderOrder = 1;
+      coast.renderOrder = 20;
       coast.frustumCulled = false;
     }
     updateLineProjection(coast, coastStyle);
@@ -143,7 +143,7 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
       });
       graticules = new THREE.LineSegments(geometry, material);
       graticules.name = "graticules";
-      graticules.renderOrder = 1;
+      graticules.renderOrder = 20;
       graticules.frustumCulled = false;
     }
     updateLineProjection(graticules, graticuleStyle);

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -78,6 +78,13 @@ export function useGridScene(options: UseGridSceneOptions) {
 
   let init = true;
   let currentOffset = 0;
+  // Counts consecutive frames where OrbitControls reported no camera change.
+  // The loop keeps running until this reaches IDLE_FRAMES_BEFORE_STOP so that
+  // the damping delta in OrbitControls is fully drained to zero before we
+  // stop calling update(). Without this, residual velocity would be applied
+  // the next time anything triggers a render (click, bounds change, etc.).
+  let idleFrameCount = 0;
+  const IDLE_FRAMES_BEFORE_STOP = 30; // ~500 ms at 60 fps – outlasts any realistic damping
   let targetOffset = 0;
   let isInitialLoad = true;
 
@@ -673,13 +680,24 @@ export function useGridScene(options: UseGridSceneOptions) {
       refreshHover();
     }
     const cam = getCamera();
-    if (!mouseDown && !store.isRotating && !controlsUpdated) {
-      if (cam) {
-        cameraState.debouncedEncodeCameraToURL(cam);
+    if (!mouseDown && !store.isRotating) {
+      if (controlsUpdated) {
+        // Controls are still moving (damping draining) – reset idle counter.
+        idleFrameCount = 0;
+      } else {
+        idleFrameCount++;
       }
-      return;
-    } else if (isPresenterActive.value) {
-      if (cam) {
+      if (idleFrameCount >= IDLE_FRAMES_BEFORE_STOP) {
+        // Damping is fully drained – safe to stop the loop.
+        idleFrameCount = 0;
+        if (cam) {
+          cameraState.debouncedEncodeCameraToURL(cam);
+        }
+        return;
+      }
+    } else {
+      idleFrameCount = 0;
+      if (isPresenterActive.value && cam) {
         cameraState.encodeCameraToURL(cam);
       }
     }
@@ -688,12 +706,13 @@ export function useGridScene(options: UseGridSceneOptions) {
 
   function onInteractionStart() {
     mouseDown = true;
+    idleFrameCount = 0;
     animationLoop();
   }
 
   function onInteractionEnd() {
     mouseDown = false;
-    redraw();
+    animationLoop();
   }
 
   function setupHoverListeners() {

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -687,6 +687,9 @@ export function useGridScene(options: UseGridSceneOptions) {
       } else {
         idleFrameCount++;
       }
+      if (cam && isPresenterActive.value && !store.isRotating) {
+        cameraState.encodeCameraToURL(cam);
+      }
       if (idleFrameCount >= IDLE_FRAMES_BEFORE_STOP) {
         // Damping is fully drained – safe to stop the loop.
         idleFrameCount = 0;
@@ -697,7 +700,7 @@ export function useGridScene(options: UseGridSceneOptions) {
       }
     } else {
       idleFrameCount = 0;
-      if (isPresenterActive.value && cam) {
+      if (isPresenterActive.value && cam && mouseDown) {
         cameraState.encodeCameraToURL(cam);
       }
     }

--- a/src/ui/overlays/AboutModal.vue
+++ b/src/ui/overlays/AboutModal.vue
@@ -18,6 +18,7 @@ const visible = ref(false);
       Developed by Max-Planck-Institute for Meteorology (MPI-M) and the German
       Climate Computing Center (DKRZ)
     </p>
+    <p class="mt-3 is-size-7 has-text-grey">Earth texture credit: NASA.</p>
     <template #footer>
       <p>
         <a

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -46,6 +46,7 @@ const { landSeaMaskChoice, landSeaMaskUseTexture } = storeToRefs(store);
           />
           <label
             for="use_texture"
+            title="Earth texture credit: NASA"
             :class="{
               'has-text-grey-light': landSeaMaskChoice === 'off',
             }"


### PR DESCRIPTION
This pull request refactors how missing and fill values are handled in grid data rendering. Instead of passing missing/fill values to shaders and checking them in GLSL, missing and fill values are now mapped to `NaN` in JavaScript before uploading data to the GPU. The shaders only check for `NaN`, simplifying their logic and reducing the number of uniforms. The update also removes related code and uniforms across all affected grid types, and adjusts utility functions accordingly. These changes were necessary since Windows-Devices had issues with keeping the precision of fill/missing values for proper comparisons with the data points resulting specifically in very noisy fill-value-regions. Here is an example of a curvilinear dataset with a landmask enabled:

<img width="1137" height="1081" alt="image_2026-04-12_18-37-20" src="https://github.com/user-attachments/assets/79c76938-b802-4609-832d-11028a6fab4a" />

Another main feature of this PR is the refactoring of the mask-code. The mask should be now significantly faster on flat projections (I barely notice a performance slowdown compared to no-mask now) except for a slightly longer first-time-to-load. The first-time-to-load is longer because I replaced the texture by a new one with a higher resolution.
