### PR TITLE
Fix/choppy edges

### DIFF
--- a/src/lib/projection/projectionShaders.ts
+++ b/src/lib/projection/projectionShaders.ts
@@ -141,16 +141,14 @@ export const projectionShaderFunctions = `
   }
 
   // Equirectangular projection (Plate Carrée)
-  vec3 projectEquirectangular(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectEquirectangularRotated(vec2 rotated) {
     float x = rotated.y * DEG_TO_RAD;  // lon in radians
     float y = rotated.x * DEG_TO_RAD;  // lat in radians
     return vec3(x, y, 0.0);
   }
 
   // Mercator projection
-  vec3 projectMercator(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectMercatorRotated(vec2 rotated) {
     float safeLat = clamp(rotated.x, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT);
     float latRad = safeLat * DEG_TO_RAD;
     float x = rotated.y * DEG_TO_RAD;
@@ -160,8 +158,7 @@ export const projectionShaderFunctions = `
 
   // Robinson projection (using quadratic interpolation to match d3-geo-projection)
   // Uses the same 3-point interpolation formula as d3's robinsonRaw function
-  vec3 projectRobinson(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectRobinsonRotated(vec2 rotated) {
     float latRad = rotated.x * DEG_TO_RAD;
 
     // d3 formula: i = min(18, abs(phi) * 36 / pi)
@@ -193,8 +190,7 @@ export const projectionShaderFunctions = `
   }
 
   // Mollweide projection (using Newton-Raphson iteration)
-  vec3 projectMollweide(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectMollweideRotated(vec2 rotated) {
     float latRad = rotated.x * DEG_TO_RAD;
 
     // Newton-Raphson to solve 2*theta + sin(2*theta) = PI * sin(lat)
@@ -220,8 +216,7 @@ export const projectionShaderFunctions = `
   // Cylindrical Equal Area projection (Lambert)
   // Matches d3-geo-projection's geoCylindricalEqualArea output with scale(1)
   // D3 uses: x = λ / k, y = sin(φ) * k where k ≈ 1.2792 (derived from default scale)
-  vec3 projectCylindricalEqualArea(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectCylindricalEqualAreaRotated(vec2 rotated) {
     float x = rotated.y * DEG_TO_RAD / CYLINDRICAL_EQUAL_AREA_SCALE;
     float y = sin(rotated.x * DEG_TO_RAD) * CYLINDRICAL_EQUAL_AREA_SCALE;
     return vec3(x, y, 0.0);
@@ -229,13 +224,7 @@ export const projectionShaderFunctions = `
 
   // Azimuthal blend between equal-area (0.0) and equidistant (1.0)
   // This keeps the same azimuthal direction and interpolates the radial distance.
-  vec3 projectAzimuthalHybrid(
-    float lat,
-    float lon,
-    float centerLon,
-    float centerLat
-  ) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectAzimuthalHybridRotated(vec2 rotated) {
     float latRad = rotated.x * DEG_TO_RAD;
     float lonRad = rotated.y * DEG_TO_RAD;
 
@@ -250,7 +239,6 @@ export const projectionShaderFunctions = `
       float nan = sqrt(-1.0);
       return vec3(nan, nan, nan);
     }
-
     if (c < 0.0001) {
       return vec3(0.0, 0.0, 0.0);
     }
@@ -277,28 +265,21 @@ export const projectionShaderFunctions = `
 
   // Azimuthal Equidistant projection
   // Distances from center point are preserved
-  vec3 projectAzimuthalEquidistant(float lat, float lon, float centerLon, float centerLat) {
-    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+  vec3 projectAzimuthalEquidistantRotated(vec2 rotated) {
     float latRad = rotated.x * DEG_TO_RAD;
     float lonRad = rotated.y * DEG_TO_RAD;
 
-    // Angular distance from center (which is now at 0,0 after rotation)
     float cosC = cos(latRad) * cos(lonRad);
     float c = acos(clamp(cosC, -1.0, 1.0));
 
-    // Clip points beyond the configured clip angle to avoid antipodal singularity
-    // Return NaN to cause GPU to discard the geometry entirely
     if (c > AZIMUTHAL_CLIP_ANGLE_RAD) {
-      float nan = sqrt(-1.0);  // Generate NaN
+      float nan = sqrt(-1.0);
       return vec3(nan, nan, nan);
     }
-
-    // Handle the center point (c = 0)
     if (c < 0.0001) {
       return vec3(0.0, 0.0, 0.0);
     }
 
-    // Compute k = c / sin(c)
     float sinC = sin(c);
     float k = c / sinC;
 
@@ -306,6 +287,99 @@ export const projectionShaderFunctions = `
     float y = k * sin(latRad);
 
     return vec3(x, y, 0.0);
+  }
+
+  vec3 projectRotatedLatLon(vec2 rotated, int projectionType, float radius) {
+    if (projectionType == PROJ_EQUIRECTANGULAR) {
+      return projectEquirectangularRotated(rotated) * radius;
+    } else if (projectionType == PROJ_MERCATOR) {
+      return projectMercatorRotated(rotated) * radius;
+    } else if (projectionType == PROJ_ROBINSON) {
+      return projectRobinsonRotated(rotated) * radius;
+    } else if (projectionType == PROJ_MOLLWEIDE) {
+      return projectMollweideRotated(rotated) * radius;
+    } else if (projectionType == PROJ_CYLINDRICAL_EQUAL_AREA) {
+      return projectCylindricalEqualAreaRotated(rotated) * radius;
+    } else if (projectionType == PROJ_AZIMUTHAL_HYBRID) {
+      return projectAzimuthalHybridRotated(rotated) * radius;
+    } else if (projectionType == PROJ_AZIMUTHAL_EQUIDISTANT) {
+      return projectAzimuthalEquidistantRotated(rotated) * radius;
+    } else {
+      return projectGlobe(rotated.x, rotated.y, radius);
+    }
+  }
+
+  float robinsonXLimit(float y) {
+    float absY = abs(y);
+    if (absY > robinsonK[39]) return -1.0;
+
+    int i0 = 0;
+    for (int i = 0; i <= 17; i++) {
+      if (absY <= robinsonK[(i + 2) * 2 + 1]) {
+        i0 = i;
+        break;
+      }
+      i0 = i;
+    }
+
+    float ax = robinsonK[i0 * 2];
+    float ay = robinsonK[i0 * 2 + 1];
+    float bx = robinsonK[(i0 + 1) * 2];
+    float by = robinsonK[(i0 + 1) * 2 + 1];
+    float cx = robinsonK[(i0 + 2) * 2];
+    float cy = robinsonK[(i0 + 2) * 2 + 1];
+
+    float di = (abs(cy - by) > 0.0001) ? (absY - by) / (cy - by) : 0.0;
+    di = clamp(di, 0.0, 1.0);
+    for (int iter = 0; iter < 5; iter++) {
+      float yCoeff = by + di * (cy - ay) / 2.0 + di * di * (cy - 2.0 * by + ay) / 2.0;
+      float dyCoeff = (cy - ay) / 2.0 + di * (cy - 2.0 * by + ay);
+      if (abs(dyCoeff) < 0.0001) break;
+      di = clamp(di - (yCoeff - absY) / dyCoeff, 0.0, 1.0);
+    }
+
+    float xCoeff = bx + di * (cx - ax) / 2.0 + di * di * (cx - 2.0 * bx + ax) / 2.0;
+    return xCoeff * PI;
+  }
+
+  bool isInsideProjectionDomain(vec2 projected, int projectionType, float radius) {
+    float safeRadius = max(abs(radius), 0.0001);
+    vec2 p = projected / safeRadius;
+    float epsilon = 0.0005;
+
+    if (projectionType == PROJ_EQUIRECTANGULAR) {
+      return abs(p.x) <= PI + epsilon && abs(p.y) <= PI * 0.5 + epsilon;
+    } else if (projectionType == PROJ_MERCATOR) {
+      float latLimitRad = MERCATOR_LAT_LIMIT * DEG_TO_RAD;
+      float yLimit = log(tan(PI / 4.0 + latLimitRad / 2.0));
+      return abs(p.x) <= PI + epsilon && abs(p.y) <= yLimit + epsilon;
+    } else if (projectionType == PROJ_ROBINSON) {
+      float xLimit = robinsonXLimit(p.y);
+      return xLimit >= 0.0 && abs(p.x) <= xLimit + epsilon;
+    } else if (projectionType == PROJ_MOLLWEIDE) {
+      float yLimit = sqrt(2.0);
+      float xLimit = 2.0 * sqrt(2.0) * sqrt(max(0.0, 1.0 - (p.y * p.y) / 2.0));
+      return abs(p.y) <= yLimit + epsilon && abs(p.x) <= xLimit + epsilon;
+    } else if (projectionType == PROJ_CYLINDRICAL_EQUAL_AREA) {
+      return
+        abs(p.x) <= PI / CYLINDRICAL_EQUAL_AREA_SCALE + epsilon &&
+        abs(p.y) <= CYLINDRICAL_EQUAL_AREA_SCALE + epsilon;
+    } else if (projectionType == PROJ_AZIMUTHAL_EQUIDISTANT || projectionType == PROJ_AZIMUTHAL_HYBRID) {
+      return length(p) <= AZIMUTHAL_CLIP_ANGLE_RAD + epsilon;
+    }
+
+    return true;
+  }
+
+  // Kept as a direct helper for inverse-projection validation in land/sea-mask shaders.
+  vec3 projectAzimuthalHybrid(
+    float lat,
+    float lon,
+    float centerLon,
+    float centerLat
+  ) {
+    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+    return projectAzimuthalHybridRotated(rotated);
   }
 
   // Main projection function that dispatches to the appropriate projection
@@ -317,23 +391,12 @@ export const projectionShaderFunctions = `
     float centerLat,
     float radius
   ) {
-    if (projectionType == PROJ_AZIMUTHAL_HYBRID) {
-      return projectAzimuthalHybrid(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_AZIMUTHAL_EQUIDISTANT) {
-      return projectAzimuthalEquidistant(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_EQUIRECTANGULAR) {
-      return projectEquirectangular(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_MERCATOR) {
-      return projectMercator(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_ROBINSON) {
-      return projectRobinson(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_MOLLWEIDE) {
-      return projectMollweide(lat, lon, centerLon, centerLat) * radius;
-    } else if (projectionType == PROJ_CYLINDRICAL_EQUAL_AREA) {
-      return projectCylindricalEqualArea(lat, lon, centerLon, centerLat) * radius;
-    } else {
+    if (projectionType == PROJ_GLOBE) {
       return projectGlobe(lat, lon, radius);
     }
+
+    vec2 rotated = rotateCoords(lat, lon, centerLon, centerLat);
+    return projectRotatedLatLon(rotated, projectionType, radius);
   }
 `;
 

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -38,6 +38,43 @@ float posterize(float value, float levels) {
 `;
 
 const projectionWrapVertexGLSL = `
+bool projectionUsesWrappedInstances(int projType) {
+  return
+    projType != PROJ_GLOBE &&
+    projType != PROJ_AZIMUTHAL_EQUIDISTANT &&
+    projType != PROJ_AZIMUTHAL_HYBRID;
+}
+
+bool shouldCullTriangleWrapInstance(
+  vec2 triLatLon0,
+  vec2 triLatLon1,
+  vec2 triLatLon2,
+  int projType,
+  float cLon,
+  float cLat,
+  float wrapDir,
+  int edgeQuality,
+  int useTriangleWrapCull
+) {
+  if (
+    edgeQuality <= 0 ||
+    useTriangleWrapCull <= 0 ||
+    !projectionUsesWrappedInstances(projType)
+  ) {
+    return false;
+  }
+
+  float lon0 = rotateCoords(triLatLon0.x, triLatLon0.y, cLon, cLat).y;
+  float lon1 = rotateCoords(triLatLon1.x, triLatLon1.y, cLon, cLat).y;
+  float lon2 = rotateCoords(triLatLon2.x, triLatLon2.y, cLon, cLat).y;
+  float minLon = min(lon0, min(lon1, lon2));
+  float maxLon = max(lon0, max(lon1, lon2));
+  bool crossesWrap = maxLon - minLon > 180.0;
+  bool isBaseInstance = abs(wrapDir) < 0.5;
+
+  return crossesWrap ? isBaseInstance : !isBaseInstance;
+}
+
 vec3 projectWithWrap(
   vec2 latLon,
   int projType,
@@ -281,15 +318,36 @@ uniform float centerLon;
 uniform float centerLat;
 uniform float projectionRadius;
 uniform int edgeQuality;
+uniform int useTriangleWrapCull;
 
 attribute vec2 latLon;  // lat, lon in degrees
 attribute float wrapDirection;
+attribute vec2 triangleLatLon0;
+attribute vec2 triangleLatLon1;
+attribute vec2 triangleLatLon2;
 
 varying vec2 vUv;
 varying vec2 vProjectedXY;
 
 void main() {
   vUv = uv;
+  if (
+    shouldCullTriangleWrapInstance(
+      triangleLatLon0,
+      triangleLatLon1,
+      triangleLatLon2,
+      projectionType,
+      centerLon,
+      centerLat,
+      wrapDirection,
+      edgeQuality,
+      useTriangleWrapCull
+    )
+  ) {
+    vProjectedXY = vec2(1000000.0);
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
   vec3 projected = projectWithWrap(
     latLon,
     projectionType,
@@ -409,6 +467,7 @@ export function makeGpuProjectedTextureMaterial(
       centerLat: { value: 0.0 },
       projectionRadius: { value: 1.0 },
       edgeQuality: { value: 1 },
+      useTriangleWrapCull: { value: 0 },
     },
     transparent: true,
     vertexShader: gpuProjectedTextureVertexShader,
@@ -417,6 +476,12 @@ export function makeGpuProjectedTextureMaterial(
   (material.defaultAttributeValues as Record<string, unknown>).wrapDirection = [
     0,
   ];
+  (material.defaultAttributeValues as Record<string, unknown>).triangleLatLon0 =
+    [0, 0];
+  (material.defaultAttributeValues as Record<string, unknown>).triangleLatLon1 =
+    [0, 0];
+  (material.defaultAttributeValues as Record<string, unknown>).triangleLatLon2 =
+    [0, 0];
   return material;
 }
 

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -37,7 +37,33 @@ float posterize(float value, float levels) {
 }
 `;
 
+const projectionWrapVertexGLSL = `
+vec3 projectWithWrap(
+  vec2 latLon,
+  int projType,
+  float cLon,
+  float cLat,
+  float radius,
+  float wrapDir,
+  int edgeQuality
+) {
+  // Globe projection is oriented by the camera; projection center must not rotate it.
+  if (projType == PROJ_GLOBE) {
+    return projectGlobe(latLon.x, latLon.y, radius);
+  }
+  vec2 rotated = rotateCoords(latLon.x, latLon.y, cLon, cLat);
+  if (edgeQuality > 0 && wrapDir > 0.5 && rotated.y < 0.0) {
+    rotated.y += 360.0;
+  } else if (edgeQuality > 0 && wrapDir < -0.5 && rotated.y > 0.0) {
+    rotated.y -= 360.0;
+  }
+  return projectRotatedLatLon(rotated, projType, radius);
+}
+`;
+
 const textureColormapFragmentShader = `
+${projectionShaderFunctions}
+
 ${colormapShaders}
 
 ${isNaNGLSL}
@@ -50,10 +76,17 @@ uniform int colormap;
 uniform float posterizeLevels;
 uniform float hideBelowValue;
 uniform sampler2D data;
+uniform int projectionType;
+uniform float projectionRadius;
+uniform int edgeQuality;
 
 varying vec2 vUv;
+varying vec2 vProjectedXY;
 
 void main() {
+  if (edgeQuality > 0 && !isInsideProjectionDomain(vProjectedXY, projectionType, projectionRadius)) {
+        discard;
+    }
     gl_FragColor.a = 1.0;
     float v_value = texture(data, vUv).r;
     if (is_nan(v_value) || v_value <= hideBelowValue) {
@@ -69,6 +102,8 @@ void main() {
 // credits: https://www.shadertoy.com/view/3lBXR3
 //          https://github.com/mzucker/fit_colormaps
 const scalarColormapFragmentShader = `
+${projectionShaderFunctions}
+
 ${colormapShaders}
 
 ${isNaNGLSL}
@@ -81,9 +116,18 @@ uniform float scaleFactor;
 uniform int colormap;
 uniform float posterizeLevels;
 uniform float hideBelowValue;
+uniform int projectionType;
+uniform float projectionRadius;
+uniform int edgeQuality;
+
+varying vec2 vProjectedXY;
 
 void main() {
-    if (is_nan(v_value) || v_value <= hideBelowValue) {
+    if (
+    (edgeQuality > 0 && !isInsideProjectionDomain(vProjectedXY, projectionType, projectionRadius)) ||
+        is_nan(v_value) ||
+        v_value <= hideBelowValue
+    ) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
@@ -230,25 +274,32 @@ export function getColormapScaleOffset(
 const gpuProjectedTextureVertexShader = `
 ${projectionShaderFunctions}
 
+${projectionWrapVertexGLSL}
+
 uniform int projectionType;
 uniform float centerLon;
 uniform float centerLat;
 uniform float projectionRadius;
+uniform int edgeQuality;
 
 attribute vec2 latLon;  // lat, lon in degrees
+attribute float wrapDirection;
 
 varying vec2 vUv;
+varying vec2 vProjectedXY;
 
 void main() {
   vUv = uv;
-  vec3 projected = projectLatLon(
-    latLon.x,
-    latLon.y,
+  vec3 projected = projectWithWrap(
+    latLon,
     projectionType,
     centerLon,
     centerLat,
-    projectionRadius
+    projectionRadius,
+    wrapDirection,
+    edgeQuality
   );
+  vProjectedXY = projected.xy;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(projected, 1.0);
 }
 `;
@@ -260,27 +311,34 @@ void main() {
 const gpuProjectedMeshVertexShader = `
 ${projectionShaderFunctions}
 
+${projectionWrapVertexGLSL}
+
 uniform int projectionType;
 uniform float centerLon;
 uniform float centerLat;
 uniform float projectionRadius;
 uniform float pointSize;
+uniform int edgeQuality;
 
 attribute vec2 latLon;  // lat, lon in degrees
 attribute float data_value;
+attribute float wrapDirection;
 
 varying float v_value;
+varying vec2 vProjectedXY;
 
 void main() {
   v_value = data_value;
-  vec3 projected = projectLatLon(
-    latLon.x,
-    latLon.y,
+  vec3 projected = projectWithWrap(
+    latLon,
     projectionType,
     centerLon,
     centerLat,
-    projectionRadius
+    projectionRadius,
+    wrapDirection,
+    edgeQuality
   );
+  vProjectedXY = projected.xy;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(projected, 1.0);
   if (pointSize > 0.0) {
     gl_PointSize = pointSize;
@@ -350,11 +408,15 @@ export function makeGpuProjectedTextureMaterial(
       centerLon: { value: 0.0 },
       centerLat: { value: 0.0 },
       projectionRadius: { value: 1.0 },
+      edgeQuality: { value: 1 },
     },
     transparent: true,
     vertexShader: gpuProjectedTextureVertexShader,
     fragmentShader: textureColormapFragmentShader,
   });
+  (material.defaultAttributeValues as Record<string, unknown>).wrapDirection = [
+    0,
+  ];
   return material;
 }
 
@@ -382,11 +444,15 @@ export function makeGpuProjectedMeshMaterial(
       centerLon: { value: 0.0 },
       centerLat: { value: 0.0 },
       projectionRadius: { value: 1.0 },
+      edgeQuality: { value: 1 },
     },
     transparent: true,
     vertexShader: gpuProjectedMeshVertexShader,
     fragmentShader: scalarColormapFragmentShader,
   });
+  (material.defaultAttributeValues as Record<string, unknown>).wrapDirection = [
+    0,
+  ];
   return material;
 }
 
@@ -433,7 +499,9 @@ export function makeGpuProjectedPointMaterial(
 export function updateProjectionUniforms(
   material: THREE.ShaderMaterial,
   projectionHelper: Pick<ProjectionHelper, "type" | "center">,
-  radius: number = 1.0
+  radius: number = 1.0,
+  mesh?: THREE.Mesh,
+  useAccurateEdges = true
 ) {
   const projectionTypeId = getProjectionTypeFromMode(projectionHelper.type);
   if (material.uniforms.projectionType) {
@@ -448,6 +516,92 @@ export function updateProjectionUniforms(
   if (material.uniforms.projectionRadius) {
     material.uniforms.projectionRadius.value = radius;
   }
+  if (material.uniforms.edgeQuality) {
+    material.uniforms.edgeQuality.value = useAccurateEdges ? 1 : 0;
+  }
   material.depthTest =
     projectionHelper.type === PROJECTION_TYPES.NEARSIDE_PERSPECTIVE;
+
+  if (mesh) {
+    setProjectionGeometryInstanceCount(
+      mesh.geometry,
+      getProjectionInstanceCount(projectionHelper.type, useAccurateEdges)
+    );
+  }
+}
+
+function getProjectionInstanceCount(
+  projectionType: Pick<ProjectionHelper, "type">["type"],
+  useAccurateEdges: boolean
+) {
+  return useAccurateEdges && shouldUseProjectionWrapInstances(projectionType)
+    ? 3
+    : 1;
+}
+
+function shouldUseProjectionWrapInstances(
+  projectionType: Pick<ProjectionHelper, "type">["type"]
+) {
+  return (
+    projectionType !== PROJECTION_TYPES.NEARSIDE_PERSPECTIVE &&
+    projectionType !== PROJECTION_TYPES.AZIMUTHAL_EQUIDISTANT &&
+    projectionType !== PROJECTION_TYPES.AZIMUTHAL_HYBRID
+  );
+}
+
+function setProjectionGeometryInstanceCount(
+  geometry: THREE.BufferGeometry,
+  count: number
+) {
+  const instancedGeometry = geometry as THREE.InstancedBufferGeometry;
+  if (instancedGeometry.isInstancedBufferGeometry) {
+    if (instancedGeometry.instanceCount === count) {
+      return;
+    }
+    instancedGeometry.instanceCount = count;
+  }
+}
+
+/**
+ * Add the instanced wrapDirection attribute to a geometry.
+ * Must be called on every new geometry before it is used in a projection mesh.
+ */
+export function addWrapDirectionAttribute(
+  geometry: THREE.InstancedBufferGeometry
+): void {
+  setProjectionGeometryInstanceCount(geometry, 1);
+
+  const wrapDirs = new Float32Array([0, 1, -1]);
+  geometry.setAttribute(
+    "wrapDirection",
+    new THREE.InstancedBufferAttribute(wrapDirs, 1)
+  );
+}
+
+/**
+ * Create the most efficient projection mesh for the current projection mode.
+ * Uses a plain Mesh with InstancedBufferGeometry instead of InstancedMesh,
+ * avoiding instanceMatrix/program overhead because wrapDirection is the only
+ * per-instance value we need.
+ *
+ * The geometry renders up to 3 wrap instances:
+ * Instance 0: wrapDirection=0 (normal rendering)
+ * Instance 1: wrapDirection=+1 (shift negative rotatedLon by +360)
+ * Instance 2: wrapDirection=-1 (shift positive rotatedLon by -360)
+ * Call addWrapDirectionAttribute(geometry) before calling this.
+ */
+export function createProjectionInstancedMesh(
+  geometry: THREE.InstancedBufferGeometry,
+  material: THREE.Material,
+  projectionType?: Pick<ProjectionHelper, "type">["type"],
+  useAccurateEdges = true
+): THREE.Mesh {
+  setProjectionGeometryInstanceCount(
+    geometry,
+    projectionType
+      ? getProjectionInstanceCount(projectionType, useAccurateEdges)
+      : 1
+  );
+  const mesh = new THREE.Mesh(geometry, material);
+  return mesh;
 }

--- a/src/ui/grids/Curvilinear.vue
+++ b/src/ui/grids/Curvilinear.vue
@@ -8,6 +8,12 @@ import {
   createGeoSampleIndex,
   useGridHoverLookup,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  setupProjectionGeometryWrap,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -19,10 +25,7 @@ import {
   getLatLonData,
   mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
-import {
-  makeGpuProjectedMeshMaterial,
-  updateProjectionUniforms,
-} from "@/lib/shaders/gridShaders.ts";
+import { makeGpuProjectedMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
@@ -72,6 +75,7 @@ const {
   updateLandSeaMask,
   updateColormap,
   projectionHelper,
+  isSceneInMotion,
   canvas,
   box,
   updateHistogram,
@@ -118,29 +122,23 @@ watch(
   }
 );
 
-// GPU projection: update shader uniforms instead of rebuilding geometry
-watch(
-  [() => projectionMode.value, () => projectionCenter.value],
-  () => {
-    updateMeshProjectionUniforms();
-  },
-  { deep: true }
-);
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
+});
 
 /**
  * Update projection uniforms on all mesh materials.
  * This is the fast path - no geometry rebuild needed.
  */
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-
-  for (const mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    if (material.uniforms?.projectionType) {
-      updateProjectionUniforms(material, helper);
-    }
-  }
-  redraw();
+  updateProjectionMeshes(meshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 const colormapMaterial = computed(() => {
@@ -326,7 +324,7 @@ function createBatchGeometry(
   latLonValues: Float32Array,
   indices: Uint32Array
 ) {
-  const geometry = new THREE.BufferGeometry();
+  const geometry = new THREE.InstancedBufferGeometry();
 
   geometry.setAttribute(
     "position",
@@ -341,14 +339,19 @@ function createBatchGeometry(
 
 function updateBatchMesh(
   batchIndex: number,
-  geometry: THREE.BufferGeometry,
+  geometry: THREE.InstancedBufferGeometry,
   meshes: THREE.Mesh[]
 ) {
+  setupProjectionGeometryWrap(geometry);
   if (meshes[batchIndex]) {
     meshes[batchIndex].geometry.dispose();
     meshes[batchIndex].geometry = geometry;
   } else {
-    const mesh = new THREE.Mesh(geometry, colormapMaterial.value);
+    const mesh = createWrappedProjectionMesh(
+      geometry,
+      colormapMaterial.value,
+      projectionHelper.value.type
+    );
     mesh.frustumCulled = false;
     meshes.push(mesh);
     getScene()?.add(mesh);

--- a/src/ui/grids/GaussianReduced.vue
+++ b/src/ui/grids/GaussianReduced.vue
@@ -8,6 +8,12 @@ import {
   createGeoSampleIndex,
   useGridHoverLookup,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  setupProjectionGeometryWrap,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -19,10 +25,7 @@ import {
   mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
-import {
-  makeGpuProjectedMeshMaterial,
-  updateProjectionUniforms,
-} from "@/lib/shaders/gridShaders.ts";
+import { makeGpuProjectedMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
@@ -72,6 +75,7 @@ const {
   updateLandSeaMask,
   updateColormap,
   projectionHelper,
+  isSceneInMotion,
   canvas,
   box,
   updateHistogram,
@@ -118,17 +122,19 @@ watch(
   }
 );
 
-watch([() => projectionMode.value, () => projectionCenter.value], () => {
-  updateMeshProjectionUniforms();
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
 });
 
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-
-  for (const mesh of meshes) {
-    updateProjectionUniforms(mesh.material as THREE.ShaderMaterial, helper);
-  }
-  redraw();
+  updateProjectionMeshes(meshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 const colormapMaterial = computed(() => {
@@ -152,13 +158,18 @@ const BATCH_SIZE = 64; // Adjust based on memory and browser limits
 
 function updateOrCreateMesh(
   batchIndex: number,
-  geometry: THREE.BufferGeometry
+  geometry: THREE.InstancedBufferGeometry
 ) {
+  setupProjectionGeometryWrap(geometry);
   if (meshes[batchIndex]) {
     meshes[batchIndex].geometry.dispose();
     meshes[batchIndex].geometry = geometry;
   } else {
-    const mesh = new THREE.Mesh(geometry, colormapMaterial.value);
+    const mesh = createWrappedProjectionMesh(
+      geometry,
+      colormapMaterial.value,
+      projectionHelper.value.type
+    );
     mesh.frustumCulled = false;
     meshes.push(mesh);
     getScene()?.add(mesh);
@@ -183,7 +194,7 @@ function createBatchGeometry(
   latLonValues: Float32Array,
   indices: Uint32Array
 ) {
-  const geometry = new THREE.BufferGeometry();
+  const geometry = new THREE.InstancedBufferGeometry();
 
   geometry.setAttribute(
     "position",

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -10,6 +10,7 @@ import {
   type TGridHoverLookupResult,
 } from "./composables/gridHoverUtils.ts";
 import {
+  createTriangleWrapProjectionGeometry,
   createWrappedProjectionMesh,
   setupProjectionGeometryWrap,
   updateProjectionMeshes,
@@ -428,7 +429,7 @@ function createGeometry(
     "latLon",
     new THREE.Float32BufferAttribute(latLonValues, 2)
   );
-  return geometry;
+  return createTriangleWrapProjectionGeometry(geometry);
 }
 
 function generateHealpixIndices(positionValues: Float32Array, steps: number) {
@@ -807,6 +808,7 @@ onBeforeMount(async () => {
       addOffset,
       scaleFactor
     );
+    material.uniforms.useTriangleWrapCull.value = 1;
     // Set initial projection uniforms
     const helper = projectionHelper.value;
     updateProjectionUniforms(material, helper);

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -9,6 +9,12 @@ import {
   useGridHoverLookup,
   type TGridHoverLookupResult,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  setupProjectionGeometryWrap,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -78,6 +84,7 @@ const {
   updateColormap,
   updateHistogram,
   projectionHelper,
+  isSceneInMotion,
   canvas,
   box,
   hoveredGeoPoint,
@@ -94,11 +101,7 @@ const hoverNside = ref<number | null>(null);
 
 const HEALPIX_NUMCHUNKS = 12;
 
-let mainMeshes: THREE.Mesh<
-  THREE.BufferGeometry<THREE.NormalBufferAttributes>,
-  THREE.Material,
-  THREE.Object3DEventMap
->[] = new Array(HEALPIX_NUMCHUNKS);
+let mainMeshes: Array<THREE.Mesh | undefined> = new Array(HEALPIX_NUMCHUNKS);
 
 watch(
   () => varnameSelector.value,
@@ -144,29 +147,23 @@ watch(
   }
 );
 
-// GPU projection: update shader uniforms instead of rebuilding geometry
-watch(
-  [() => projectionMode.value, () => projectionCenter.value],
-  () => {
-    updateMeshProjectionUniforms();
-  },
-  { deep: true }
-);
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
+});
 
 /**
  * Update projection uniforms on all mesh materials.
  * This is the fast path - no geometry rebuild needed.
  */
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-
-  for (const mesh of mainMeshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    if (material.uniforms?.projectionType) {
-      updateProjectionUniforms(material, helper);
-    }
-  }
-  redraw();
+  updateProjectionMeshes(mainMeshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 async function datasourceUpdate() {
@@ -189,8 +186,13 @@ function fetchGrid() {
         gridStep,
         projectionHelper.value
       );
-      mainMeshes[ipix].geometry.dispose();
-      mainMeshes[ipix].geometry = geometry;
+      const mesh = mainMeshes[ipix];
+      if (!mesh) {
+        continue;
+      }
+      mesh.geometry.dispose();
+      setupProjectionGeometryWrap(geometry);
+      mesh.geometry = geometry;
     }
     // Update projection uniforms after geometry change
     updateMeshProjectionUniforms();
@@ -414,7 +416,7 @@ function createGeometry(
   latLonValues: Float32Array,
   indices: number[]
 ) {
-  const geometry = new THREE.BufferGeometry();
+  const geometry = new THREE.InstancedBufferGeometry();
   geometry.setIndex(indices);
   geometry.setAttribute(
     "position",
@@ -652,7 +654,11 @@ async function processHealpixChunks(
         indices
       );
       if (texData === undefined) {
-        const material = mainMeshes[ipix].material as THREE.ShaderMaterial;
+        const mesh = mainMeshes[ipix];
+        if (!mesh) {
+          return;
+        }
+        const material = mesh.material as THREE.ShaderMaterial;
         material.uniforms.data.value.dispose();
         return;
       }
@@ -661,7 +667,11 @@ async function processHealpixChunks(
       dataMin = dataMin > texData.min ? texData.min : dataMin;
       dataMax = dataMax < texData.max ? texData.max : dataMax;
 
-      const material = mainMeshes[ipix].material as THREE.ShaderMaterial;
+      const mesh = mainMeshes[ipix];
+      if (!mesh) {
+        return;
+      }
+      const material = mesh.material as THREE.ShaderMaterial;
       material.uniforms.data.value.dispose();
       material.uniforms.data.value = texData.texture;
 
@@ -772,7 +782,10 @@ async function fetchAndRenderData(
 
 onMounted(() => {
   for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ++ipix) {
-    getScene()!.add(mainMeshes[ipix]);
+    const mesh = mainMeshes[ipix];
+    if (mesh) {
+      getScene()!.add(mesh);
+    }
   }
 });
 
@@ -804,9 +817,14 @@ onBeforeMount(async () => {
       gridStep,
       projectionHelper.value
     );
-    mainMeshes[ipix] = new THREE.Mesh(geometry, material);
+    const mesh = createWrappedProjectionMesh(
+      geometry,
+      material,
+      projectionHelper.value.type
+    );
+    mainMeshes[ipix] = mesh;
     // Disable frustum culling - GPU projection changes actual positions
-    mainMeshes[ipix].frustumCulled = false;
+    mesh.frustumCulled = false;
   }
   await datasourceUpdate();
 });

--- a/src/ui/grids/IrregularDelaunay.vue
+++ b/src/ui/grids/IrregularDelaunay.vue
@@ -9,6 +9,11 @@ import {
   createGeoSampleIndex,
   useGridHoverLookup,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -24,10 +29,7 @@ import {
   PROJECTION_TYPES,
   ProjectionHelper,
 } from "@/lib/projection/projectionUtils.ts";
-import {
-  makeGpuProjectedMeshMaterial,
-  updateProjectionUniforms,
-} from "@/lib/shaders/gridShaders.ts";
+import { makeGpuProjectedMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
@@ -81,6 +83,7 @@ const {
   updateLandSeaMask,
   updateColormap,
   projectionHelper,
+  isSceneInMotion,
   redraw,
   canvas,
   box,
@@ -138,29 +141,23 @@ watch(
   }
 );
 
-// GPU projection: update shader uniforms instead of rebuilding geometry
-watch(
-  [() => projectionMode.value, () => projectionCenter.value],
-  () => {
-    updateMeshProjectionUniforms();
-  },
-  { deep: true }
-);
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
+});
 
 /**
  * Update projection uniforms on all mesh materials.
  * This is the fast path - no geometry rebuild needed.
  */
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-
-  for (const mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    if (material.uniforms?.projectionType) {
-      updateProjectionUniforms(material, helper);
-    }
-  }
-  redraw();
+  updateProjectionMeshes(meshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 const colormapMaterial = computed(() => {
@@ -295,7 +292,7 @@ function createMeshBatch(
   batchLatLon: Float32Array,
   batchDataValues: Float32Array
 ) {
-  const geometry = new THREE.BufferGeometry();
+  const geometry = new THREE.InstancedBufferGeometry();
   geometry.setAttribute(
     "position",
     new THREE.BufferAttribute(batchPositions, 3)
@@ -307,7 +304,11 @@ function createMeshBatch(
   );
   geometry.computeBoundingSphere();
 
-  const mesh = new THREE.Mesh(geometry, colormapMaterial.value);
+  const mesh = createWrappedProjectionMesh(
+    geometry,
+    colormapMaterial.value,
+    projectionHelper.value.type
+  );
   mesh.frustumCulled = false;
 
   meshes.push(mesh);

--- a/src/ui/grids/Regular.vue
+++ b/src/ui/grids/Regular.vue
@@ -8,6 +8,12 @@ import {
   createGeoSampleIndex,
   useGridHoverLookup,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  setupProjectionGeometryWrap,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -71,6 +77,7 @@ const {
   updateColormap,
   updateHistogram,
   projectionHelper,
+  isSceneInMotion,
   canvas,
   box,
   hoveredGeoPoint,
@@ -131,23 +138,19 @@ watch(
   }
 );
 
-watch(
-  [() => projectionMode.value, () => projectionCenter.value],
-  () => {
-    updateMeshProjectionUniforms();
-  },
-  { deep: true }
-);
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
+});
 
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-  for (const mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    if (material.uniforms?.projectionType) {
-      updateProjectionUniforms(material, helper);
-    }
-  }
-  redraw();
+  updateProjectionMeshes(meshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 async function datasourceUpdate() {
@@ -426,7 +429,7 @@ function createBatchGeometry(
   latStart: number,
   latEnd: number
 ) {
-  const geometry = new THREE.BufferGeometry();
+  const geometry = new THREE.InstancedBufferGeometry();
 
   // Extract vertices for this batch (from latStart to latEnd inclusive)
   const batchLatCount = latEnd - latStart + 1;
@@ -475,17 +478,22 @@ async function makeGeometry() {
         latEnd
       );
 
+      setupProjectionGeometryWrap(geometry);
       if (meshes[batchIndex]) {
         meshes[batchIndex].geometry.dispose();
         meshes[batchIndex].geometry = geometry;
       } else {
-        const mesh = new THREE.Mesh(geometry, new THREE.ShaderMaterial());
+        const mesh = createWrappedProjectionMesh(
+          geometry,
+          new THREE.ShaderMaterial(),
+          projectionHelper.value.type
+        );
         mesh.frustumCulled = false;
         meshes.push(mesh);
         getScene()?.add(mesh);
       }
     }
-    redraw();
+    updateMeshProjectionUniforms();
   } catch (error) {
     logError(error, "Could not fetch grid");
   }

--- a/src/ui/grids/Triangular.vue
+++ b/src/ui/grids/Triangular.vue
@@ -8,6 +8,11 @@ import {
   createGeoSampleIndex,
   useGridHoverLookup,
 } from "./composables/gridHoverUtils.ts";
+import {
+  createWrappedProjectionMesh,
+  updateProjectionMeshes,
+  watchProjectionEdgeQuality,
+} from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
@@ -18,10 +23,7 @@ import {
   mapMissingAndFillToNaN,
 } from "@/lib/data/zarrUtils.ts";
 import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
-import {
-  makeGpuProjectedMeshMaterial,
-  updateProjectionUniforms,
-} from "@/lib/shaders/gridShaders.ts";
+import { makeGpuProjectedMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
@@ -71,6 +73,7 @@ const {
   updateLandSeaMask,
   updateColormap,
   projectionHelper,
+  isSceneInMotion,
   canvas,
   box,
   updateHistogram,
@@ -124,29 +127,23 @@ watch(
   }
 );
 
-// GPU projection: update shader uniforms instead of rebuilding geometry
-watch(
-  [() => projectionMode.value, () => projectionCenter.value],
-  () => {
-    updateMeshProjectionUniforms();
-  },
-  { deep: true }
-);
+watchProjectionEdgeQuality({
+  projectionMode,
+  projectionCenter,
+  isSceneInMotion,
+  onUpdate: updateMeshProjectionUniforms,
+});
 
 /**
  * Update projection uniforms on all mesh materials.
  * This is the fast path - no geometry rebuild needed.
  */
 function updateMeshProjectionUniforms() {
-  const helper = projectionHelper.value;
-
-  for (const mesh of meshes) {
-    const material = mesh.material as THREE.ShaderMaterial;
-    if (material.uniforms?.projectionType) {
-      updateProjectionUniforms(material, helper);
-    }
-  }
-  redraw();
+  updateProjectionMeshes(meshes, {
+    redraw,
+    projectionHelper: projectionHelper.value,
+    isSceneInMotion: isSceneInMotion.value,
+  });
 }
 
 const colormapMaterial = computed(() => {
@@ -190,6 +187,16 @@ function cleanupMeshes() {
 // Split triangles into batches for multiple meshes
 const BATCH_SIZE = 3000000; // number of triangles per mesh (tune as needed)
 
+function createTriangleMesh(geometry: THREE.InstancedBufferGeometry) {
+  const mesh = createWrappedProjectionMesh(
+    geometry,
+    colormapMaterial.value,
+    projectionHelper.value.type
+  );
+  mesh.frustumCulled = false;
+  return mesh;
+}
+
 async function fetchGrid() {
   try {
     const verts = await grid2buffer(gridsource.value!);
@@ -199,7 +206,7 @@ async function fetchGrid() {
     const nTriangles = verts.length / 9;
     for (let i = 0; i < nTriangles; i += BATCH_SIZE) {
       const count = Math.min(BATCH_SIZE, nTriangles - i);
-      const geometry = new THREE.BufferGeometry();
+      const geometry = new THREE.InstancedBufferGeometry();
       // Each triangle has 9 values (3 vertices * 3 coords)
       const batchVerts = verts.subarray(i * 9, (i + count) * 9);
       const positionValues = new Float32Array(batchVerts.length);
@@ -232,9 +239,7 @@ async function fetchGrid() {
         new THREE.BufferAttribute(latLonValues, 2)
       );
       geometry.computeBoundingSphere();
-      const mesh = new THREE.Mesh(geometry, colormapMaterial.value);
-      // Disable frustum culling - GPU projection changes actual positions
-      mesh.frustumCulled = false;
+      const mesh = createTriangleMesh(geometry);
       meshes.push(mesh);
       getScene()?.add(mesh);
     }

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -18,6 +18,8 @@ import { useGridSnapshot } from "./useGridSnapshot.ts";
 
 import { handleKeyDown } from "@/lib/camera/OrbitControlsAddOn.ts";
 import {
+  isAzimuthalProjectionType,
+  MERCATOR_LAT_LIMIT,
   PROJECTION_TYPES,
   ProjectionHelper,
   type TProjectionCenter,
@@ -35,6 +37,7 @@ type UseGridSceneOptions = {
   projectionCenter: Ref<TProjectionCenter | undefined>;
   controlPanelVisible: Ref<boolean>;
   cameraState: GridCameraState;
+  onMotionStateChange?: (isInMotion: boolean) => void;
   onReady?: () => void | Promise<void>;
 };
 
@@ -45,6 +48,7 @@ export function useGridScene(options: UseGridSceneOptions) {
     projectionCenter,
     controlPanelVisible,
     cameraState,
+    onMotionStateChange,
     onReady,
   } = options;
 
@@ -75,7 +79,6 @@ export function useGridScene(options: UseGridSceneOptions) {
   let dragStartY = 0;
   let dragStartCenterLon = 0;
   let dragStartCenterLat = 0;
-
   let init = true;
   let currentOffset = 0;
   // Counts consecutive frames where OrbitControls reported no camera change.
@@ -85,8 +88,20 @@ export function useGridScene(options: UseGridSceneOptions) {
   // the next time anything triggers a render (click, bounds change, etc.).
   let idleFrameCount = 0;
   const IDLE_FRAMES_BEFORE_STOP = 30; // ~500 ms at 60 fps – outlasts any realistic damping
+  const FLAT_CROP_RENDER_ORDER = 5;
+  const FLAT_CROP_Z_OFFSET = 0.06;
+  const FLAT_BOUNDARY_STEP_DEGREES = 0.25;
   let targetOffset = 0;
   let isInitialLoad = true;
+  let isInMotion = false;
+
+  function setMotionState(next: boolean) {
+    if (isInMotion === next) {
+      return;
+    }
+    isInMotion = next;
+    onMotionStateChange?.(next);
+  }
 
   function getScene() {
     return scene;
@@ -258,13 +273,32 @@ export function useGridScene(options: UseGridSceneOptions) {
     };
   }
 
-  function cleanupSurface(mesh: THREE.Mesh | undefined) {
+  function disposeObject3D(object: THREE.Object3D) {
+    const geometries = new Set<THREE.BufferGeometry>();
+    const materials = new Set<THREE.Material>();
+
+    object.traverse((child) => {
+      if (!(child instanceof THREE.Mesh)) {
+        return;
+      }
+      geometries.add(child.geometry);
+      if (Array.isArray(child.material)) {
+        child.material.forEach((material) => materials.add(material));
+      } else {
+        materials.add(child.material);
+      }
+    });
+
+    geometries.forEach((geometry) => geometry.dispose());
+    materials.forEach((material) => material.dispose());
+  }
+
+  function cleanupSurface(mesh: THREE.Object3D | undefined) {
     if (!scene || !mesh) {
       return;
     }
     scene.remove(mesh);
-    mesh.geometry.dispose();
-    (mesh.material as THREE.Material).dispose();
+    disposeObject3D(mesh);
   }
 
   function makePickMaterial(doubleSided = false) {
@@ -278,18 +312,142 @@ export function useGridScene(options: UseGridSceneOptions) {
     return material;
   }
 
+  function appendBoundaryPoint(points: THREE.Vector2[], x: number, y: number) {
+    const point = new THREE.Vector2(x, y);
+    const previous = points[points.length - 1];
+    if (previous && previous.distanceToSquared(point) < 1e-10) {
+      return;
+    }
+    points.push(point);
+  }
+
+  function projectBoundaryPoint(
+    projection: d3.GeoProjection,
+    bounds: ReturnType<typeof getProjectedBounds>,
+    points: THREE.Vector2[],
+    lon: number,
+    lat: number
+  ) {
+    const projected = projection([lon, lat]);
+    if (
+      !projected ||
+      !Number.isFinite(projected[0]) ||
+      !Number.isFinite(projected[1])
+    ) {
+      return;
+    }
+    appendBoundaryPoint(
+      points,
+      projected[0] - bounds.centerX,
+      -projected[1] - bounds.centerY
+    );
+  }
+
+  function createFlatBoundaryPoints(
+    bounds: ReturnType<typeof getProjectedBounds>
+  ) {
+    const helper = projectionHelper.value;
+    if (isAzimuthalProjectionType(helper.type)) {
+      return [];
+    }
+
+    const projection = new ProjectionHelper(helper.type, {
+      lat: 0,
+      lon: 0,
+    }).getD3Projection();
+    if (!projection) {
+      return [];
+    }
+
+    const points: THREE.Vector2[] = [];
+    const maxLat =
+      helper.type === PROJECTION_TYPES.MERCATOR ? MERCATOR_LAT_LIMIT : 90;
+
+    for (let lon = -180; lon <= 180; lon += FLAT_BOUNDARY_STEP_DEGREES) {
+      projectBoundaryPoint(projection, bounds, points, lon, maxLat);
+    }
+    for (
+      let lat = maxLat - FLAT_BOUNDARY_STEP_DEGREES;
+      lat >= -maxLat;
+      lat -= FLAT_BOUNDARY_STEP_DEGREES
+    ) {
+      projectBoundaryPoint(projection, bounds, points, 180, lat);
+    }
+    for (
+      let lon = 180 - FLAT_BOUNDARY_STEP_DEGREES;
+      lon >= -180;
+      lon -= FLAT_BOUNDARY_STEP_DEGREES
+    ) {
+      projectBoundaryPoint(projection, bounds, points, lon, -maxLat);
+    }
+    for (
+      let lat = -maxLat + FLAT_BOUNDARY_STEP_DEGREES;
+      lat <= maxLat;
+      lat += FLAT_BOUNDARY_STEP_DEGREES
+    ) {
+      projectBoundaryPoint(projection, bounds, points, -180, lat);
+    }
+
+    return points;
+  }
+
+  function createFlatCropGeometry(
+    bounds: ReturnType<typeof getProjectedBounds>,
+    scaledWidth: number,
+    scaledHeight: number
+  ) {
+    const boundaryPoints = createFlatBoundaryPoints(bounds);
+    if (boundaryPoints.length < 3) {
+      return undefined;
+    }
+
+    const halfWidth = scaledWidth / 2;
+    const halfHeight = scaledHeight / 2;
+    const outerShape = new THREE.Shape([
+      new THREE.Vector2(-halfWidth, -halfHeight),
+      new THREE.Vector2(halfWidth, -halfHeight),
+      new THREE.Vector2(halfWidth, halfHeight),
+      new THREE.Vector2(-halfWidth, halfHeight),
+    ]);
+    outerShape.holes.push(new THREE.Path(boundaryPoints));
+    return new THREE.ShapeGeometry(outerShape);
+  }
+
+  function createBackgroundMaterial() {
+    return new THREE.MeshBasicMaterial({
+      color: 0x000000,
+      depthTest: false,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      transparent: true,
+    });
+  }
+
   function createFlatSurfaces() {
     const bounds = getProjectedBounds();
     const width = Math.max(bounds.width, 1);
     const height = Math.max(bounds.height, 1);
     const scaledWidth = width * 1.05;
     const scaledHeight = height * 1.05;
-
+    const backgroundMaterial = createBackgroundMaterial();
     baseSurface = new THREE.Mesh(
       new THREE.PlaneGeometry(scaledWidth, scaledHeight),
-      new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide })
+      backgroundMaterial
     );
+    baseSurface.renderOrder = -10;
     baseSurface.position.set(bounds.centerX, bounds.centerY, -0.05);
+
+    const cropGeometry = createFlatCropGeometry(
+      bounds,
+      scaledWidth,
+      scaledHeight
+    );
+    if (cropGeometry) {
+      const cropSurface = new THREE.Mesh(cropGeometry, backgroundMaterial);
+      cropSurface.renderOrder = FLAT_CROP_RENDER_ORDER;
+      cropSurface.position.z = FLAT_CROP_Z_OFFSET;
+      baseSurface.add(cropSurface);
+    }
 
     pickSurface = new THREE.Mesh(
       new THREE.PlaneGeometry(scaledWidth, scaledHeight),
@@ -676,6 +834,7 @@ export function useGridScene(options: UseGridSceneOptions) {
     }
 
     const controlsUpdated = render();
+    setMotionState(mouseDown || store.isRotating || controlsUpdated);
     if (lastPointerPosition) {
       refreshHover();
     }
@@ -693,6 +852,7 @@ export function useGridScene(options: UseGridSceneOptions) {
       if (idleFrameCount >= IDLE_FRAMES_BEFORE_STOP) {
         // Damping is fully drained – safe to stop the loop.
         idleFrameCount = 0;
+        setMotionState(false);
         if (cam) {
           cameraState.debouncedEncodeCameraToURL(cam);
         }
@@ -710,6 +870,7 @@ export function useGridScene(options: UseGridSceneOptions) {
   function onInteractionStart() {
     mouseDown = true;
     idleFrameCount = 0;
+    setMotionState(true);
     animationLoop();
   }
 

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -416,10 +416,7 @@ export function useGridScene(options: UseGridSceneOptions) {
   function createBackgroundMaterial() {
     return new THREE.MeshBasicMaterial({
       color: 0x000000,
-      depthTest: false,
-      depthWrite: false,
       side: THREE.DoubleSide,
-      transparent: true,
     });
   }
 
@@ -459,8 +456,6 @@ export function useGridScene(options: UseGridSceneOptions) {
   function createGlobeSurfaces() {
     const backgroundMaterial = new THREE.MeshBasicMaterial({
       color: 0x000000,
-      depthTest: false,
-      depthWrite: false,
     });
     baseSurface = new THREE.Mesh(
       new THREE.SphereGeometry(0.99, 64, 64),

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -136,7 +136,7 @@ export function useGridScene(options: UseGridSceneOptions) {
   }
 
   function redraw() {
-    if (store.isRotating) {
+    if (store.isRotating || projectionDragActive) {
       return;
     }
     render();

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -1,5 +1,6 @@
 import { useEventListener } from "@vueuse/core";
 import * as d3 from "d3-geo";
+import debounce from "lodash.debounce";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import {
@@ -70,6 +71,7 @@ export function useGridScene(options: UseGridSceneOptions) {
   let baseSurface: THREE.Mesh | undefined = undefined;
   let pickSurface: THREE.Mesh | undefined = undefined;
   let mouseDown = false;
+  let wheelActive = false;
   const raycaster = new THREE.Raycaster();
   const hoveredGeoPoint = shallowRef<THoverGeoPoint | null>(null);
   let lastPointerPosition: { clientX: number; clientY: number } | null = null;
@@ -88,6 +90,11 @@ export function useGridScene(options: UseGridSceneOptions) {
   // the next time anything triggers a render (click, bounds change, etc.).
   let idleFrameCount = 0;
   const IDLE_FRAMES_BEFORE_STOP = 30; // ~500 ms at 60 fps – outlasts any realistic damping
+  const WHEEL_END_DELAY_MS = 120;
+  const debouncedEndWheelInteraction = debounce(() => {
+    wheelActive = false;
+    animationLoop();
+  }, WHEEL_END_DELAY_MS);
   const FLAT_CROP_RENDER_ORDER = 5;
   const FLAT_CROP_Z_OFFSET = 0.06;
   const FLAT_BOUNDARY_STEP_DEGREES = 0.25;
@@ -835,12 +842,15 @@ export function useGridScene(options: UseGridSceneOptions) {
     }
 
     const controlsUpdated = render();
-    setMotionState(mouseDown || store.isRotating || controlsUpdated);
+    const userInteractionActive = mouseDown || wheelActive;
+    setMotionState(
+      userInteractionActive || store.isRotating || controlsUpdated
+    );
     if (lastPointerPosition) {
       refreshHover();
     }
     const cam = getCamera();
-    if (!mouseDown && !store.isRotating) {
+    if (!userInteractionActive && !store.isRotating) {
       if (controlsUpdated) {
         // Controls are still moving (damping draining) – reset idle counter.
         idleFrameCount = 0;
@@ -861,7 +871,7 @@ export function useGridScene(options: UseGridSceneOptions) {
       }
     } else {
       idleFrameCount = 0;
-      if (isPresenterActive.value && cam && mouseDown) {
+      if (isPresenterActive.value && cam && userInteractionActive) {
         cameraState.encodeCameraToURL(cam);
       }
     }
@@ -877,6 +887,13 @@ export function useGridScene(options: UseGridSceneOptions) {
 
   function onInteractionEnd() {
     mouseDown = false;
+    animationLoop();
+  }
+
+  function onWheelInteraction() {
+    wheelActive = true;
+    idleFrameCount = 0;
+    debouncedEndWheelInteraction();
     animationLoop();
   }
 
@@ -911,15 +928,9 @@ export function useGridScene(options: UseGridSceneOptions) {
   function setupInteractionListeners() {
     setupHoverListeners();
 
-    useEventListener(
-      canvas.value,
-      "wheel",
-      () => {
-        onInteractionStart();
-        onInteractionEnd();
-      },
-      { passive: true }
-    );
+    useEventListener(canvas.value, "wheel", onWheelInteraction, {
+      passive: true,
+    });
 
     useEventListener(canvas.value, "mouseup", onInteractionEnd, {
       passive: true,
@@ -1052,6 +1063,7 @@ export function useGridScene(options: UseGridSceneOptions) {
     scene?.clear();
     camera?.clear();
     renderer?.dispose();
+    debouncedEndWheelInteraction.cancel();
     if (box.value) {
       getResizeObserver()?.unobserve(box.value!);
     }

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -457,10 +457,16 @@ export function useGridScene(options: UseGridSceneOptions) {
   }
 
   function createGlobeSurfaces() {
+    const backgroundMaterial = new THREE.MeshBasicMaterial({
+      color: 0x000000,
+      depthTest: false,
+      depthWrite: false,
+    });
     baseSurface = new THREE.Mesh(
       new THREE.SphereGeometry(0.99, 64, 64),
-      new THREE.MeshBasicMaterial({ color: 0x000000 })
+      backgroundMaterial
     );
+    baseSurface.renderOrder = -10;
     baseSurface.rotation.x = Math.PI / 2;
 
     pickSurface = new THREE.Mesh(

--- a/src/ui/grids/composables/useProjectionEdgeQuality.ts
+++ b/src/ui/grids/composables/useProjectionEdgeQuality.ts
@@ -1,0 +1,83 @@
+import * as THREE from "three";
+import type { Ref } from "vue";
+import { watch } from "vue";
+
+import { type ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
+import {
+  addWrapDirectionAttribute,
+  createProjectionInstancedMesh,
+  updateProjectionUniforms,
+} from "@/lib/shaders/gridShaders.ts";
+
+type ProjectionMesh = THREE.Mesh | undefined;
+
+type ProjectionSyncOptions = {
+  redraw: () => void;
+  projectionHelper: ProjectionHelper;
+  isSceneInMotion: boolean;
+  radius?: number;
+};
+
+type ProjectionWatchOptions = {
+  projectionMode: Ref<unknown>;
+  projectionCenter: Ref<unknown>;
+  isSceneInMotion: Ref<boolean>;
+  onUpdate: () => void;
+};
+
+export function watchProjectionEdgeQuality(options: ProjectionWatchOptions) {
+  const { projectionMode, projectionCenter, isSceneInMotion, onUpdate } =
+    options;
+
+  watch([projectionMode, projectionCenter], onUpdate, { deep: true });
+  watch(isSceneInMotion, onUpdate);
+}
+
+export function updateProjectionMeshes(
+  meshes: ProjectionMesh[],
+  options: ProjectionSyncOptions
+) {
+  const { redraw, projectionHelper, isSceneInMotion, radius = 1.0 } = options;
+  const useAccurateEdges = !isSceneInMotion;
+
+  for (let i = 0; i < meshes.length; i++) {
+    const mesh = meshes[i];
+    if (!mesh) {
+      continue;
+    }
+
+    const material = mesh.material as THREE.ShaderMaterial;
+    if (material.uniforms?.projectionType) {
+      updateProjectionUniforms(
+        material,
+        projectionHelper,
+        radius,
+        mesh,
+        useAccurateEdges
+      );
+    }
+  }
+
+  redraw();
+}
+
+export function setupProjectionGeometryWrap(
+  geometry: THREE.InstancedBufferGeometry
+): void {
+  addWrapDirectionAttribute(geometry);
+}
+
+export function createWrappedProjectionMesh(
+  geometry: THREE.InstancedBufferGeometry,
+  material: THREE.Material,
+  projectionType: ProjectionHelper["type"],
+  useAccurateEdges = true
+): THREE.Mesh {
+  setupProjectionGeometryWrap(geometry);
+  return createProjectionInstancedMesh(
+    geometry,
+    material,
+    projectionType,
+    useAccurateEdges
+  );
+}

--- a/src/ui/grids/composables/useProjectionEdgeQuality.ts
+++ b/src/ui/grids/composables/useProjectionEdgeQuality.ts
@@ -25,6 +25,12 @@ type ProjectionWatchOptions = {
   onUpdate: () => void;
 };
 
+const TRIANGLE_WRAP_ATTRIBUTE_NAMES = [
+  "triangleLatLon0",
+  "triangleLatLon1",
+  "triangleLatLon2",
+] as const;
+
 export function watchProjectionEdgeQuality(options: ProjectionWatchOptions) {
   const { projectionMode, projectionCenter, isSceneInMotion, onUpdate } =
     options;
@@ -65,6 +71,71 @@ export function setupProjectionGeometryWrap(
   geometry: THREE.InstancedBufferGeometry
 ): void {
   addWrapDirectionAttribute(geometry);
+}
+
+function copyGeometryAttributes(
+  source: THREE.BufferGeometry,
+  target: THREE.InstancedBufferGeometry
+) {
+  for (const name of Object.keys(source.attributes)) {
+    target.setAttribute(name, source.getAttribute(name));
+  }
+}
+
+function setTriangleLatLonAttribute(
+  geometry: THREE.InstancedBufferGeometry,
+  latLon: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+  attributeName: string,
+  corner: number
+) {
+  const values = new Float32Array(latLon.count * 2);
+
+  for (
+    let triangleOffset = 0;
+    triangleOffset < latLon.count;
+    triangleOffset += 3
+  ) {
+    const cornerIndex = triangleOffset + corner;
+    const lat = latLon.getX(cornerIndex);
+    const lon = latLon.getY(cornerIndex);
+
+    for (let i = 0; i < 3; i++) {
+      const targetOffset = (triangleOffset + i) * 2;
+      values[targetOffset] = lat;
+      values[targetOffset + 1] = lon;
+    }
+  }
+
+  geometry.setAttribute(
+    attributeName,
+    new THREE.Float32BufferAttribute(values, 2)
+  );
+}
+
+function addTriangleLatLonAttributes(geometry: THREE.InstancedBufferGeometry) {
+  const latLon = geometry.getAttribute("latLon");
+  if (!latLon || latLon.itemSize !== 2 || latLon.count % 3 !== 0) {
+    return;
+  }
+
+  for (let corner = 0; corner < 3; corner++) {
+    setTriangleLatLonAttribute(
+      geometry,
+      latLon,
+      TRIANGLE_WRAP_ATTRIBUTE_NAMES[corner],
+      corner
+    );
+  }
+}
+
+export function createTriangleWrapProjectionGeometry(
+  geometry: THREE.InstancedBufferGeometry
+): THREE.InstancedBufferGeometry {
+  const source = geometry.index ? geometry.toNonIndexed() : geometry;
+  const result = new THREE.InstancedBufferGeometry();
+  copyGeometryAttributes(source, result);
+  addTriangleLatLonAttributes(result);
+  return result;
 }
 
 export function createWrappedProjectionMesh(

--- a/src/ui/grids/composables/useSharedGridLogic.ts
+++ b/src/ui/grids/composables/useSharedGridLogic.ts
@@ -52,6 +52,7 @@ export function useSharedGridLogic() {
   });
 
   const cameraState = useGridCameraState();
+  const isSceneInMotion = ref(false);
   let updateCoastlines: () => Promise<void> = async () => {};
   let updateGraticules: () => Promise<void> = async () => {};
 
@@ -74,6 +75,9 @@ export function useSharedGridLogic() {
     projectionCenter,
     controlPanelVisible,
     cameraState,
+    onMotionStateChange: (isInMotion) => {
+      isSceneInMotion.value = isInMotion;
+    },
     onReady: () => {
       updateCoastlines();
       updateGraticules();
@@ -347,6 +351,7 @@ export function useSharedGridLogic() {
     updateColormap,
     updateHistogram,
     projectionHelper,
+    isSceneInMotion,
     canvas,
     box,
     hoveredGeoPoint,


### PR DESCRIPTION
* Fixed #138 for still images (no motion)
* Fixed `Earth disappears when you zoom out far. On touch table in Windows at EGU.` from the #135-issue

Unfortunately, this PR introduces a lot of vibe code. Before going further with the development, I think I will do a round of refactoring next, but not on this PR.

#138 has only been fixed for still images because it introduces quite performance-heavy changes, which do not work well when in motion.