### PR TITLE
Fix/various

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,121 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Gridlook</title>
+    <title>Gridlook - Earth System Model Data Viewer</title>
+    <meta
+      name="description"
+      content="Gridlook is a WebGL-based viewer for Earth system model output, supporting interactive exploration of cloud-hosted Zarr datasets on native grids."
+    />
+    <meta
+      name="keywords"
+      content="Gridlook, Earth system model, ESM, climate data, Zarr, WebGL, native grid, data visualization, climate visualization"
+    />
+    <meta name="application-name" content="Gridlook" />
+    <meta
+      name="author"
+      content="German Climate Computing Center, Max-Planck-Institut for Meteorology"
+    />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://gridlook.pages.dev/" />
+
+    <meta
+      property="og:title"
+      content="Gridlook - WebGL Earth System Model Data Viewer"
+    />
+    <meta
+      property="og:description"
+      content="Interactively explore cloud-hosted Zarr datasets and native-grid Earth system model output directly in the browser."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://gridlook.pages.dev/" />
+    <meta property="og:site_name" content="Gridlook" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@id": "https://gridlook.pages.dev/#app",
+            "@type": "WebApplication",
+            "name": "Gridlook",
+            "url": "https://gridlook.pages.dev/",
+            "description": "Gridlook is a WebGL-based viewer for Earth system model output, supporting interactive exploration of cloud-hosted Zarr datasets on native grids.",
+            "applicationCategory": "Scientific visualization",
+            "operatingSystem": "Any",
+            "browserRequirements": "Requires JavaScript and WebGL.",
+            "isAccessibleForFree": true,
+            "license": "https://opensource.org/license/mit",
+            "screenshot": {
+              "@type": "ImageObject",
+              "url": "https://raw.githubusercontent.com/d70-t/gridlook/refs/heads/main/docs/assets/showcase.webp",
+              "contentUrl": "https://raw.githubusercontent.com/d70-t/gridlook/refs/heads/main/docs/assets/showcase.webp",
+              "encodingFormat": "image/webp",
+              "width": {
+                "@type": "QuantitativeValue",
+                "value": 600,
+                "unitText": "px"
+              },
+              "height": {
+                "@type": "QuantitativeValue",
+                "value": 426,
+                "unitText": "px"
+              },
+              "caption": "Gridlook showing Earth system model output on a globe"
+            },
+            "isBasedOn": {
+              "@id": "https://gridlook.pages.dev/#source-code"
+            },
+            "creator": [
+              {
+                "@type": "Organization",
+                "name": "German Climate Computing Center",
+                "alternateName": "DKRZ",
+                "url": "https://www.dkrz.de/"
+              },
+              {
+                "@type": "Organization",
+                "name": "Max-Planck-Institut for Meteorology",
+                "alternateName": "MPI-M",
+                "url": "https://mpimet.mpg.de/"
+              }
+            ],
+            "keywords": [
+              "Earth system model",
+              "ESM",
+              "climate data",
+              "Zarr",
+              "WebGL",
+              "native grid",
+              "data visualization",
+              "climate visualization"
+            ]
+          },
+          {
+            "@id": "https://gridlook.pages.dev/#source-code",
+            "@type": "SoftwareSourceCode",
+            "name": "Gridlook source code",
+            "url": "https://github.com/d70-t/gridlook",
+            "codeRepository": "https://github.com/d70-t/gridlook",
+            "license": "https://opensource.org/license/mit",
+            "programmingLanguage": ["TypeScript", "Vue"],
+            "runtimePlatform": "Web browser",
+            "creator": [
+              {
+                "@type": "Organization",
+                "name": "German Climate Computing Center",
+                "alternateName": "DKRZ",
+                "url": "https://www.dkrz.de/"
+              },
+              {
+                "@type": "Organization",
+                "name": "Max-Planck-Institut for Meteorology",
+                "alternateName": "MPI-M",
+                "url": "https://mpimet.mpg.de/"
+              }
+            ]
+          }
+        ]
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "fflate": "^0.8.3",
         "geokdbush": "2.1.0",
         "humanize-duration": "^3.33.2",
+        "icechunk-js": "^0.4.0",
         "kdbush": "4.0.2",
         "pinia": "^3.0.4",
         "primevue": "^4.5.5",
@@ -895,6 +896,15 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -4740,6 +4750,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -4864,6 +4880,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -5443,6 +5465,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/icechunk-js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/icechunk-js/-/icechunk-js-0.4.0.tgz",
+      "integrity": "sha512-au8ALQqpd60LAVHgeQzf0c1V7xSfvH89JFPCyjdZoy5qcQ9Uutu3h1SQBKXIa5iccf6VPjfFOYxlavoFFS8Rfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^3.1.3",
+        "flatbuffers": "^25.9.23",
+        "fzstd": "^0.1.1"
+      },
+      "peerDependencies": {
+        "zarrita": "^0.5.0 || ^0.6.0 || ^0.7.0"
+      },
+      "peerDependenciesMeta": {
+        "zarrita": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/fontawesome-free": "^7.2.0",
         "@hscmap/healpix": "^1.4.12",
         "@primevue/themes": "^4.5.4",
+        "@vuepic/vue-datepicker": "13.0.0",
         "@vueuse/core": "^14.2.1",
         "axios": "^1.15.2",
         "bulma": "^1.0.4",
@@ -505,6 +506,12 @@
         }
       }
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
+    },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
@@ -699,6 +706,68 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
+      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@floating-ui/utils": "^0.2.11",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -1926,9 +1995,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2536,15 +2605,33 @@
         }
       }
     },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-13.0.0.tgz",
+      "integrity": "sha512-7emyDtXcTDn0w1+RLcyYhdZFw2pE9EGbDuyFrN3XJju8nJVPcU822M2znrzmNdZU82R5ItyBeagZBtsYzUVy3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@floating-ui/vue": "^1.1.11",
+        "@vueuse/core": "^14.3.0",
+        "date-fns": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.0"
+      }
+    },
     "node_modules/@vueuse/core": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
-      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "14.2.1",
-        "@vueuse/shared": "14.2.1"
+        "@vueuse/metadata": "14.3.0",
+        "@vueuse/shared": "14.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2554,18 +2641,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
-      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2603,6 +2690,18 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2872,13 +2971,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3612,6 +3712,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -3622,7 +3732,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5298,6 +5407,19 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/humanize-duration": {
       "version": "3.33.2",
       "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.2.tgz",
@@ -6647,8 +6769,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fortawesome/fontawesome-free": "^7.2.0",
     "@hscmap/healpix": "^1.4.12",
     "@primevue/themes": "^4.5.4",
+    "@vuepic/vue-datepicker": "13.0.0",
     "@vueuse/core": "^14.2.1",
     "axios": "^1.15.2",
     "bulma": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fflate": "^0.8.3",
     "geokdbush": "2.1.0",
     "humanize-duration": "^3.33.2",
+    "icechunk-js": "^0.4.0",
     "kdbush": "4.0.2",
     "pinia": "^3.0.4",
     "primevue": "^4.5.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import HashGlobeView from "@/views/HashGlobeView.vue";
+import "./lib/data/codecs";
 </script>
 
 <template>

--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -181,3 +181,17 @@ input[type="range"]:focus-visible {
   outline-offset: 2px;
   border-radius: var(--bulma-radius);
 }
+
+.section-title {
+  font-weight: 700 !important;
+  text-transform: uppercase !important;
+  font-size: 0.75rem !important;
+  padding-right: 0.5rem !important;
+  padding-left: 0.5rem !important;
+  color: var(--bulma-grey) !important;
+}
+
+.borderless-btn {
+  border: none !important;
+  box-shadow: none !important;
+}

--- a/src/lib/data/ZarrDataManager.ts
+++ b/src/lib/data/ZarrDataManager.ts
@@ -1,3 +1,4 @@
+import { IcechunkStore } from "icechunk-js";
 import QuickLRU from "quick-lru";
 import * as zarr from "zarrita";
 
@@ -24,6 +25,8 @@ export type TZarrVariableMetadata = {
 };
 
 type TDatasetSource = Pick<TDataSource, "dataset" | "store">;
+type TIcechunkStore = zarr.AsyncReadable & Pick<IcechunkStore, "listNodes">;
+
 export class ZarrDataManager {
   private static pendingStore: Promise<
     zarr.Location<zarr.AsyncReadable>
@@ -38,12 +41,40 @@ export class ZarrDataManager {
     return dataset.replace(/^\/+/, "").replace(/\/+$/, "");
   }
 
+  static isIcechunkStorePath(storePath: string) {
+    return this.normalizeStorePath(storePath.split(/[?#]/)[0]).endsWith(
+      ".icechunk"
+    );
+  }
+
+  private static async createIcechunkStore(
+    storePath: string
+  ): Promise<TIcechunkStore> {
+    return await IcechunkStore.open(this.normalizeStorePath(storePath));
+  }
+
+  static async createListableIcechunkStore(storePath: string) {
+    const store = await this.createIcechunkStore(storePath);
+    const contents = store.listNodes().map((node) => ({
+      path: node.path as zarr.AbsolutePath,
+      kind: node.nodeData.type,
+    }));
+    return Object.assign(store, { contents: () => contents });
+  }
+
   public static async createNewStore(storePath: string) {
+    let store: zarr.AsyncReadable | undefined = undefined;
+    if (this.isIcechunkStorePath(storePath)) {
+      store = await this.createIcechunkStore(storePath);
+    } else {
+      store = new zarr.FetchStore(storePath, { useSuffixRequest: true });
+    }
+
     const cache = new QuickLRU<string, Uint8Array | undefined>({
       maxSize: 512,
     });
     const fetchStore = zarr.extendStore(
-      new zarr.FetchStore(storePath, { useSuffixRequest: true }),
+      store,
       (s) => zarr.withRangeCoalescing(s, { coalesceSize: 32768 }),
       (s) => zarr.withByteCaching(s, { cache: cache })
     );

--- a/src/lib/data/ZarrDataManager.ts
+++ b/src/lib/data/ZarrDataManager.ts
@@ -2,10 +2,11 @@ import { IcechunkStore } from "icechunk-js";
 import QuickLRU from "quick-lru";
 import * as zarr from "zarrita";
 
-import type {
-  TDataSource,
-  TSources,
-  TZarrFormat,
+import {
+  ZARR_FORMAT,
+  type TDataSource,
+  type TSources,
+  type TZarrFormat,
 } from "@/lib/types/GlobeTypes.ts";
 
 export type TZarrDatasetMetadata = {
@@ -62,9 +63,9 @@ export class ZarrDataManager {
     return Object.assign(store, { contents: () => contents });
   }
 
-  public static async createNewStore(storePath: string) {
+  public static async createNewStore(storePath: string, isIcechunk = false) {
     let store: zarr.AsyncReadable | undefined = undefined;
-    if (this.isIcechunkStorePath(storePath)) {
+    if (isIcechunk || this.isIcechunkStorePath(storePath)) {
       store = await this.createIcechunkStore(storePath);
     } else {
       store = new zarr.FetchStore(storePath, { useSuffixRequest: true });
@@ -88,7 +89,10 @@ export class ZarrDataManager {
     const storePath = this.normalizeStorePath(datasource.store);
     if (!this.pendingStore || this.fetchStorePath !== storePath) {
       this.fetchStorePath = storePath;
-      this.pendingStore = this.createNewStore(storePath)
+      this.pendingStore = this.createNewStore(
+        storePath,
+        format === ZARR_FORMAT.ICECHUNK
+      )
         .then((s) => zarr.root(s))
         .catch((e) => {
           // Clear the cache on failure so callers can retry.
@@ -103,9 +107,9 @@ export class ZarrDataManager {
     const datasetPath = this.normalizeDatasetPath(datasource.dataset);
     const target = datasetPath ? root.resolve(datasetPath) : root;
     let dataset: zarr.Group<zarr.AsyncReadable>;
-    if (format === 2) {
+    if (format === ZARR_FORMAT.V2) {
       dataset = await zarr.open.v2(target, { kind: "group" });
-    } else if (format === 3) {
+    } else if (format === ZARR_FORMAT.V3) {
       dataset = await zarr.open.v3(target, { kind: "group" });
     } else {
       dataset = await zarr.open(target, { kind: "group" });
@@ -119,9 +123,9 @@ export class ZarrDataManager {
     format?: TZarrFormat
   ): Promise<zarr.Array<zarr.DataType, zarr.AsyncReadable>> {
     const fetchPromise = (async () => {
-      if (format === 2) {
+      if (format === ZARR_FORMAT.V2) {
         return await zarr.open.v2(store.resolve(variable), { kind: "array" });
-      } else if (format === 3) {
+      } else if (format === ZARR_FORMAT.V3) {
         return await zarr.open.v3(store.resolve(variable), { kind: "array" });
       }
       return await zarr.open(store.resolve(variable), {

--- a/src/lib/data/codecs.ts
+++ b/src/lib/data/codecs.ts
@@ -1,0 +1,5 @@
+import { registry } from "zarrita";
+
+import { Fletcher32Codec } from "./fletcher32.ts";
+
+registry.set("numcodecs.fletcher32", async () => Fletcher32Codec);

--- a/src/lib/data/dataTexture.ts
+++ b/src/lib/data/dataTexture.ts
@@ -1,0 +1,17 @@
+export function downsampleDataTexture(
+  src: Float32Array,
+  srcWidth: number,
+  srcHeight: number,
+  dstWidth: number,
+  dstHeight: number
+): Float32Array {
+  const dst = new Float32Array(dstWidth * dstHeight);
+  for (let y = 0; y < dstHeight; y++) {
+    const srcY = Math.round((y * (srcHeight - 1)) / (dstHeight - 1));
+    for (let x = 0; x < dstWidth; x++) {
+      const srcX = Math.round((x * (srcWidth - 1)) / (dstWidth - 1));
+      dst[y * dstWidth + x] = src[srcY * srcWidth + srcX];
+    }
+  }
+  return dst;
+}

--- a/src/lib/data/dimensionHandling.ts
+++ b/src/lib/data/dimensionHandling.ts
@@ -161,8 +161,7 @@ export function buildDimensionRangesAndIndices(
   presetMaxBounds: Record<string, string>,
   oldSliderValues: (number | null)[] | null,
   indicesToIgnore: number[],
-  oldDimRanges: TDimensionRange[] | undefined,
-  keepOldValues: boolean
+  oldDimRanges: TDimensionRange[] | undefined
 ) {
   let dimensionRanges: TDimensionRange[] = [];
   dimensionRanges = createDimensionRanges(
@@ -188,8 +187,6 @@ export function buildDimensionRangesAndIndices(
         return d.startPos;
       }
     });
-  } else if (keepOldValues) {
-    indices = oldSliderValues;
   } else {
     indices = calculateIndices(dimensionRanges, oldSliderValues, oldDimRanges);
   }

--- a/src/lib/data/fletcher32.ts
+++ b/src/lib/data/fletcher32.ts
@@ -1,0 +1,71 @@
+const CHECKSUM_LENGTH = 4;
+const MAX_WORDS_PER_BLOCK = 360;
+
+export class Fletcher32Codec {
+  readonly kind = "bytes_to_bytes";
+
+  static fromConfig() {
+    return new Fletcher32Codec();
+  }
+
+  encode(): never {
+    throw new Error("encode not implemented");
+  }
+
+  decode(arr: Uint8Array): Uint8Array {
+    if (arr.byteLength <= CHECKSUM_LENGTH) {
+      throw new Error("Fletcher32 data must contain data and a checksum");
+    }
+
+    const decodedLength = arr.byteLength - CHECKSUM_LENGTH;
+    const decoded = new Uint8Array(arr.buffer, arr.byteOffset, decodedLength);
+    const expected = new DataView(
+      arr.buffer,
+      arr.byteOffset + decodedLength,
+      CHECKSUM_LENGTH
+    ).getUint32(0, true);
+
+    if (fletcher32(decoded) !== expected) {
+      throw new Error("Fletcher32 checksum mismatch");
+    }
+
+    return decoded;
+  }
+
+  computeEncodedSize(decodedSize: number): number {
+    return decodedSize + CHECKSUM_LENGTH;
+  }
+}
+
+function fletcher32(data: Uint8Array): number {
+  let sum1 = 0;
+  let sum2 = 0;
+  let offset = 0;
+  let wordsRemaining = Math.ceil(data.byteLength / 2);
+
+  while (wordsRemaining > 0) {
+    const blockLength = Math.min(wordsRemaining, MAX_WORDS_PER_BLOCK);
+    wordsRemaining -= blockLength;
+
+    for (let word = 0; word < blockLength; word += 1) {
+      sum1 += data[offset] << 8;
+      if (offset + 1 < data.byteLength) {
+        sum1 += data[offset + 1];
+      }
+      sum2 += sum1;
+      offset += 2;
+    }
+
+    sum1 = fold(sum1);
+    sum2 = fold(sum2);
+  }
+
+  sum1 = fold(sum1);
+  sum2 = fold(sum2);
+
+  return ((sum2 << 16) | sum1) >>> 0;
+}
+
+function fold(sum: number): number {
+  return (sum & 0xffff) + (sum >>> 16);
+}

--- a/src/lib/data/sourceIndexing.ts
+++ b/src/lib/data/sourceIndexing.ts
@@ -169,11 +169,14 @@ export async function indexFromIcechunk(src: string): Promise<TSources> {
     root.attrs?.title as string,
     datasources,
     src,
-    ZARR_FORMAT.V3
+    ZARR_FORMAT.ICECHUNK
   );
 }
 
 export async function indexFromZarr(src: string): Promise<TSources> {
+  if (ZarrDataManager.isIcechunkStorePath(src)) {
+    return indexFromIcechunk(src);
+  }
   try {
     const store = await zarr.withConsolidatedMetadata(
       await ZarrDataManager.createNewStore(src),
@@ -188,18 +191,25 @@ export async function indexFromZarr(src: string): Promise<TSources> {
       ZARR_FORMAT.V2
     );
   } catch {
-    const store = await zarr.withConsolidatedMetadata(
-      await ZarrDataManager.createNewStore(src),
-      { format: "v3" }
-    );
-    const root = await zarr.open(store, { kind: "group" });
-    const datasources = await processZarrVariables(store, root, src);
-    return createIndex(
-      root.attrs?.title as string,
-      datasources,
-      src,
-      ZARR_FORMAT.V3
-    );
+    try {
+      const store = await zarr.withConsolidatedMetadata(
+        await ZarrDataManager.createNewStore(src),
+        { format: "v3" }
+      );
+      const root = await zarr.open(store, { kind: "group" });
+      const datasources = await processZarrVariables(store, root, src);
+      return createIndex(
+        root.attrs?.title as string,
+        datasources,
+        src,
+        ZARR_FORMAT.V3
+      );
+    } catch {
+      // Some icechunk datasets do not use `.icechunk` suffix, so we try to detect
+      // and read them with the icechunk reader as a fallback before giving up and
+      // trying the JSON index.
+      return indexFromIcechunk(src);
+    }
   }
 }
 

--- a/src/lib/data/sourceIndexing.ts
+++ b/src/lib/data/sourceIndexing.ts
@@ -161,6 +161,18 @@ function createIndex(
   };
 }
 
+export async function indexFromIcechunk(src: string): Promise<TSources> {
+  const store = await ZarrDataManager.createListableIcechunkStore(src);
+  const root = await zarr.open.v3(store, { kind: "group" });
+  const datasources = await processZarrVariables(store, root, src);
+  return createIndex(
+    root.attrs?.title as string,
+    datasources,
+    src,
+    ZARR_FORMAT.V3
+  );
+}
+
 export async function indexFromZarr(src: string): Promise<TSources> {
   try {
     const store = await zarr.withConsolidatedMetadata(

--- a/src/lib/data/timeHandling.ts
+++ b/src/lib/data/timeHandling.ts
@@ -4,12 +4,17 @@ import * as zarr from "zarrita";
 
 dayjs.extend(utc);
 
+const unitsRegEx = /([a-zA-Z]+) since (.+)$/i;
+
+export function isTimeUnits(units: unknown): units is string {
+  return typeof units === "string" && unitsRegEx.test(units);
+}
+
 /**
  * Parses CF-style time units string (e.g., "seconds since 2020-01-01T00:00:00")
  * Returns the interval unit and reference datetime.
  */
 function parseTimeUnits(units: string): { interval: string; ref: Dayjs } {
-  const unitsRegEx = /([a-zA-Z]+) since (.+)$/i;
   const regExMatch = units.match(unitsRegEx);
   if (!regExMatch) {
     throw new Error("time units not recognized");

--- a/src/lib/types/GlobeTypes.ts
+++ b/src/lib/types/GlobeTypes.ts
@@ -6,6 +6,7 @@ import type { TColorMap } from "@/lib/shaders/colormapShaders.ts";
 export const ZARR_FORMAT = {
   V2: 2,
   V3: 3,
+  ICECHUNK: -1, // Not a standard Zarr format, but used internally to indicate icechunk stores
 } as const;
 
 export type TZarrFormat = (typeof ZARR_FORMAT)[keyof typeof ZARR_FORMAT];

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -71,9 +71,35 @@ export const useGlobeControlStore = defineStore("globeControl", {
       hoveredGridPoint: undefined as THoveredGridPoint | undefined,
       catalogUrl: undefined as string | undefined,
       catalogData: undefined as TCatalog | undefined,
+      // will get incremented each time a new dataset OR a new variable in the
+      // same dataset is loaded; used to trigger reactivity in child components
+      // that need to reload data when the variable changes
+      // if the value is even, the change is a new dataset; if odd, it's a
+      // variable change within the same dataset
+      newDatasetSignifier: 0 as number,
     };
   },
   actions: {
+    signifyDatasetChange() {
+      if (this.newDatasetSignifier % 2 === 0) {
+        this.newDatasetSignifier += 2;
+      } else {
+        this.newDatasetSignifier += 1;
+      }
+    },
+    signifyVariableChange() {
+      if (this.newDatasetSignifier % 2 === 0) {
+        this.newDatasetSignifier += 1;
+      } else {
+        this.newDatasetSignifier += 2;
+      }
+    },
+    isNewDataset(): boolean {
+      return this.newDatasetSignifier % 2 === 0;
+    },
+    isVariableChange(): boolean {
+      return this.newDatasetSignifier % 2 === 1;
+    },
     toggleRotating() {
       this.isRotating = !this.isRotating;
     },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,6 +12,7 @@ import {
 import type { TColorMap } from "@/lib/shaders/colormapShaders.ts";
 import type { TVarInfo, TBounds } from "@/lib/types/GlobeTypes.ts";
 import type { TCatalog } from "@/utils/catalog.ts";
+import type { THistogramSummary } from "@/utils/histogram.ts";
 
 export const HOVERED_GRID_POINT_STATUS = {
   VALUE: "value",
@@ -46,6 +47,7 @@ export const useGlobeControlStore = defineStore("globeControl", {
       selection: { low: 0, high: 0 } as TBounds, // all the knobs and buttons in GlobeControl which do not require a reload
       histogram: undefined as number[] | undefined, // selection-range histogram bins
       fullHistogram: undefined as number[] | undefined, // fixed histogram over full data range
+      histogramSummary: undefined as THistogramSummary | undefined, // full-resolution (4096-bin) summary
       colormap: "turbo" as TColorMap,
       invertColormap: false,
       posterizeLevels: 0 as number,
@@ -169,6 +171,9 @@ export const useGlobeControlStore = defineStore("globeControl", {
     },
     updateFullHistogram(histogram: number[] | undefined) {
       this.fullHistogram = histogram;
+    },
+    updateHistogramSummary(summary: THistogramSummary | undefined) {
+      this.histogramSummary = summary;
     },
     setControlPanelVisible(visible: boolean) {
       this.controlPanelVisible = visible;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,13 +13,6 @@ import type { TColorMap } from "@/lib/shaders/colormapShaders.ts";
 import type { TVarInfo, TBounds } from "@/lib/types/GlobeTypes.ts";
 import type { TCatalog } from "@/utils/catalog.ts";
 
-export const UPDATE_MODE = {
-  INITIAL_LOAD: "initialLoad",
-  SLIDER_TOGGLE: "sliderToggle",
-} as const;
-
-export type TUpdateMode = (typeof UPDATE_MODE)[keyof typeof UPDATE_MODE];
-
 export const HOVERED_GRID_POINT_STATUS = {
   VALUE: "value",
   MISSING: "missing",
@@ -126,12 +119,17 @@ export const useGlobeControlStore = defineStore("globeControl", {
         this.dimSlidersDisplay[i] = this.dimSlidersValues[i];
       }
     },
-    updateVarInfo(
-      varinfo: TVarInfo,
-      indices: number[],
-      updateMode: TUpdateMode
-    ) {
-      if (updateMode === UPDATE_MODE.INITIAL_LOAD) {
+    updateVarInfo(varinfo: TVarInfo, indices: number[]) {
+      const sliderValuesChanged =
+        indices.length !== this.dimSlidersValues.length ||
+        indices.some((index, i) => index !== this.dimSlidersValues[i]);
+      console.log(
+        "updateVarInfo",
+        this.dimSlidersValues,
+        indices,
+        sliderValuesChanged
+      );
+      if (sliderValuesChanged) {
         this.isInitializingVariable = true;
         this.dimSlidersValues = indices;
         this.dimSlidersDisplay = indices;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -54,7 +54,7 @@ export const useGlobeControlStore = defineStore("globeControl", {
       histogram: undefined as number[] | undefined, // selection-range histogram bins
       fullHistogram: undefined as number[] | undefined, // fixed histogram over full data range
       colormap: "turbo" as TColorMap,
-      invertColormap: true,
+      invertColormap: false,
       posterizeLevels: 0 as number,
       hideLowerBound: false,
       userBoundsLow: undefined as number | undefined,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -125,12 +125,6 @@ export const useGlobeControlStore = defineStore("globeControl", {
       const sliderValuesChanged =
         indices.length !== this.dimSlidersValues.length ||
         indices.some((index, i) => index !== this.dimSlidersValues[i]);
-      console.log(
-        "updateVarInfo",
-        this.dimSlidersValues,
-        indices,
-        sliderValuesChanged
-      );
       if (sliderValuesChanged) {
         this.isInitializingVariable = true;
         this.dimSlidersValues = indices;

--- a/src/ui/common/CollapsibleCard.vue
+++ b/src/ui/common/CollapsibleCard.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { onUnmounted, ref } from "vue";
+import { ref } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -11,9 +11,6 @@ const props = withDefaults(
 );
 
 const isCollapsed = ref(false);
-onUnmounted(() => {
-  console.log("UNMOUnT");
-});
 </script>
 
 <template>

--- a/src/ui/common/CollapsibleCard.vue
+++ b/src/ui/common/CollapsibleCard.vue
@@ -1,0 +1,66 @@
+<script lang="ts" setup>
+import { onUnmounted, ref } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    title?: string;
+  }>(),
+  {
+    title: "",
+  }
+);
+
+const isCollapsed = ref(false);
+onUnmounted(() => {
+  console.log("UNMOUnT");
+});
+</script>
+
+<template>
+  <div class="box m-2 p-2">
+    <div
+      class="is-flex is-align-items-center is-justify-content-space-between"
+      :class="isCollapsed ? '' : 'mb-2'"
+    >
+      <div class="section-title">{{ props.title }}</div>
+      <button
+        class="button borderless-btn"
+        type="button"
+        :aria-expanded="!isCollapsed"
+        :aria-label="
+          isCollapsed ? `Expand ${props.title}` : `Collapse ${props.title}`
+        "
+        @click="isCollapsed = !isCollapsed"
+      >
+        <span class="icon">
+          <i
+            class="fa-solid"
+            :class="isCollapsed ? 'fa-angle-down' : 'fa-angle-up'"
+            aria-hidden="true"
+          ></i>
+        </span>
+      </button>
+    </div>
+    <div
+      class="collapsible-card-content"
+      :class="{ 'is-collapsed': isCollapsed }"
+      :inert="isCollapsed"
+    >
+      <div class="is-clipped">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.collapsible-card-content {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.collapsible-card-content.is-collapsed {
+  grid-template-rows: 0fr;
+}
+</style>

--- a/src/ui/grids/Curvilinear.vue
+++ b/src/ui/grids/Curvilinear.vue
@@ -27,7 +27,7 @@ import {
 import { makeInvertableGpuMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import { useGlobeControlStore, type TUpdateMode } from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 
 const props = defineProps<{
   datasources?: TSources;
@@ -668,8 +668,7 @@ async function renderGridAndHover(
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const dimensionNames = await ZarrDataManager.getDimensionNames(
     props.datasources!,
@@ -683,8 +682,7 @@ async function fetchAndRenderData(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     [datavar.shape.length - 2, datavar.shape.length - 1],
-    varinfo.value?.dimRanges,
-    false
+    varinfo.value?.dimRanges
   );
 
   const rawData = castDataVarToFloat32(
@@ -708,8 +706,7 @@ async function fetchAndRenderData(
       bounds: { low: min, high: max },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
 
   redraw();

--- a/src/ui/grids/Curvilinear.vue
+++ b/src/ui/grids/Curvilinear.vue
@@ -219,6 +219,17 @@ function getNextColumnIndex(
   return (i + 1) % ni;
 }
 
+function getPreviousColumnIndex(
+  i: number,
+  ni: number,
+  flipLongitude: boolean
+): number {
+  if (flipLongitude) {
+    return (i + 1) % ni;
+  }
+  return i === 0 ? ni - 1 : i - 1;
+}
+
 // Calculate the four corner indices for a grid cell
 function getCellCornerIndices(
   j: number,
@@ -235,25 +246,92 @@ function getCellCornerIndices(
   };
 }
 
-// Extract corner coordinates for a cell
-function extractCellCorners(
-  indices: { idx00: number; idx01: number; idx10: number; idx11: number },
+function mirrorBoundaryPoint(
+  center: { lat: number; lon: number },
+  innerBoundary: { lat: number; lon: number }
+) {
+  const longitudeOffset = ((innerBoundary.lon - center.lon + 540) % 360) - 180;
+
+  return {
+    lat: 2 * center.lat - innerBoundary.lat,
+    lon: center.lon - longitudeOffset,
+  };
+}
+
+function getBoundaryPoint(
+  row: number,
+  fromColumn: number,
+  toColumn: number,
+  ni: number,
   latitudes: Float64Array,
   longitudes: Float64Array
 ) {
-  const { idx00, idx01, idx11, idx10 } = indices;
+  return getCellCenter(
+    latitudes,
+    longitudes,
+    row * ni + fromColumn,
+    row * ni + toColumn,
+    (row + 1) * ni + fromColumn,
+    (row + 1) * ni + toColumn
+  );
+}
+
+function getRowMidpoint(
+  row: number,
+  fromColumn: number,
+  toColumn: number,
+  ni: number,
+  latitudes: Float64Array,
+  longitudes: Float64Array
+) {
+  return getCellCenter(
+    latitudes,
+    longitudes,
+    row * ni + fromColumn,
+    row * ni + toColumn,
+    row * ni + fromColumn,
+    row * ni + toColumn
+  );
+}
+
+// Derive shared midpoint boundaries around the cell's source coordinate.
+function getCenteredCellCorners(
+  j: number,
+  i: number,
+  ni: number,
+  flipLongitude: boolean,
+  latitudes: Float64Array,
+  longitudes: Float64Array
+) {
+  const iPrevious = getPreviousColumnIndex(i, ni, flipLongitude);
+  const iNext = getNextColumnIndex(i, ni, flipLongitude);
+  const boundary = (row: number, fromColumn: number, toColumn: number) =>
+    getBoundaryPoint(row, fromColumn, toColumn, ni, latitudes, longitudes);
+  const midpoint = (fromColumn: number, toColumn: number) =>
+    getRowMidpoint(j, fromColumn, toColumn, ni, latitudes, longitudes);
+  const forwardPrevious = boundary(j, iPrevious, i);
+  const forwardNext = boundary(j, i, iNext);
+  const backwardPrevious =
+    j === 0
+      ? mirrorBoundaryPoint(midpoint(iPrevious, i), forwardPrevious)
+      : boundary(j - 1, iPrevious, i);
+  const backwardNext =
+    j === 0
+      ? mirrorBoundaryPoint(midpoint(i, iNext), forwardNext)
+      : boundary(j - 1, i, iNext);
+
   return {
     latPoints: [
-      latitudes[idx00],
-      latitudes[idx01],
-      latitudes[idx11],
-      latitudes[idx10],
+      backwardPrevious.lat,
+      backwardNext.lat,
+      forwardNext.lat,
+      forwardPrevious.lat,
     ],
     lonPoints: [
-      longitudes[idx00],
-      longitudes[idx01],
-      longitudes[idx11],
-      longitudes[idx10],
+      backwardPrevious.lon,
+      backwardNext.lon,
+      forwardNext.lon,
+      forwardPrevious.lon,
     ],
   };
 }
@@ -397,14 +475,12 @@ function buildBatchGeometryData(
 
   for (let j = jStart; j < jEnd; j++) {
     for (let i = 0; i < ni; i++) {
-      const { idx00, idx01, idx10, idx11 } = getCellCornerIndices(
+      const { idx00 } = getCellCornerIndices(j, i, ni, flipLongitude);
+      const { latPoints, lonPoints } = getCenteredCellCorners(
         j,
         i,
         ni,
-        flipLongitude
-      );
-      const { latPoints, lonPoints } = extractCellCorners(
-        { idx00, idx01, idx10, idx11 },
+        flipLongitude,
         latitudes,
         longitudes
       );
@@ -532,25 +608,11 @@ function buildCurvilinearHoverSamples(
 
   for (let j = 0; j < nj - 1; j++) {
     for (let i = 0; i < ni; i++) {
-      const { idx00, idx01, idx10, idx11 } = getCellCornerIndices(
-        j,
-        i,
-        ni,
-        flipLongitude
-      );
-      // Keep hover sampling colocated with rendered quads by using a cell center.
-      const { lat, lon } = getCellCenter(
-        latitudes,
-        longitudes,
-        idx00,
-        idx01,
-        idx10,
-        idx11
-      );
+      const { idx00 } = getCellCornerIndices(j, i, ni, flipLongitude);
 
       samples.push({
-        lat,
-        lon,
+        lat: latitudes[idx00],
+        lon: longitudes[idx00],
         value: rawData[idx00],
       });
     }

--- a/src/ui/grids/GaussianReduced.vue
+++ b/src/ui/grids/GaussianReduced.vue
@@ -27,11 +27,7 @@ import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import { makeInvertableGpuMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 
 const props = defineProps<{
   datasources?: TSources;
@@ -369,8 +365,7 @@ async function getDimensionValues(
 }
 
 async function buildDimensionConfig(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const dimensionNames = await ZarrDataManager.getDimensionNames(
     props.datasources!,
@@ -384,19 +379,14 @@ async function buildDimensionConfig(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     [datavar.shape.length - 1],
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
-  const { dimensionRanges, indices } = await buildDimensionConfig(
-    datavar,
-    updateMode
-  );
+  const { dimensionRanges, indices } = await buildDimensionConfig(datavar);
 
   const rawData = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
@@ -436,8 +426,7 @@ async function fetchAndRenderData(
       bounds: { low: min, high: max },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
   redraw();
 }

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -37,9 +37,7 @@ import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
   HOVERED_GRID_POINT_STATUS,
-  UPDATE_MODE,
   useGlobeControlStore,
-  type TUpdateMode,
 } from "@/store/store.ts";
 import {
   HISTOGRAM_SUMMARY_BINS,
@@ -526,8 +524,7 @@ function data2texture(
 }
 
 async function prepareDimensionData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const dimensionNames = await ZarrDataManager.getDimensionNames(
     props.datasources!,
@@ -541,8 +538,7 @@ async function prepareDimensionData(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     [datavar.shape.length - 1],
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
 
   return { dimensionRanges, indices };
@@ -658,13 +654,9 @@ function healpixHoverLookup(
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
-  const { dimensionRanges, indices } = await prepareDimensionData(
-    datavar,
-    updateMode
-  );
+  const { dimensionRanges, indices } = await prepareDimensionData(datavar);
 
   const cellCoord = await getCells();
   const nside = await getNside();
@@ -702,8 +694,7 @@ async function fetchAndRenderData(
       bounds: { low: dataMin, high: dataMax },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
 }
 

--- a/src/ui/grids/Irregular.vue
+++ b/src/ui/grids/Irregular.vue
@@ -25,11 +25,7 @@ import {
 } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 
 const props = defineProps<{
   datasources?: TSources;
@@ -355,8 +351,7 @@ function updateHoverLookup(
 }
 
 async function buildDimensionConfig(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const { latitudes, longitudes, latitudesAttrs, longitudesAttrs } =
     await getLatLonData(datavar, props.datasources);
@@ -377,18 +372,16 @@ async function buildDimensionConfig(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     geoDims,
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
   return { latitudes, longitudes, dimensionRanges, indices };
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const { latitudes, longitudes, dimensionRanges, indices } =
-    await buildDimensionConfig(datavar, updateMode);
+    await buildDimensionConfig(datavar);
 
   const rawData = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
@@ -413,8 +406,7 @@ async function fetchAndRenderData(
       bounds: { low: min, high: max },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
 }
 

--- a/src/ui/grids/IrregularDelaunay.vue
+++ b/src/ui/grids/IrregularDelaunay.vue
@@ -31,11 +31,7 @@ import {
 import { makeInvertableGpuMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 
 const props = defineProps<{
   datasources?: TSources;
@@ -609,8 +605,7 @@ function getGeographicDimensionIndices(
 }
 
 async function buildDimensionConfig(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const { latitudes, longitudes, latitudesAttrs, longitudesAttrs } =
     await getLatLonData(datavar, props.datasources);
@@ -631,8 +626,7 @@ async function buildDimensionConfig(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     geoDims,
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
   return { latitudes, longitudes, dimensionRanges, indices };
 }
@@ -663,11 +657,10 @@ function updateHoverLookup(
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const { latitudes, longitudes, dimensionRanges, indices } =
-    await buildDimensionConfig(datavar, updateMode);
+    await buildDimensionConfig(datavar);
 
   const rawData = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
@@ -691,8 +684,7 @@ async function fetchAndRenderData(
       bounds: { low: min, high: max },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
 }
 

--- a/src/ui/grids/Regular.vue
+++ b/src/ui/grids/Regular.vue
@@ -33,11 +33,7 @@ import {
 } from "@/lib/shaders/gridShaders.ts";
 import type { TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 import { useLog } from "@/utils/logging.ts";
 
 const props = defineProps<{
@@ -641,8 +637,7 @@ function nearestLonIndex(lons: Float64Array, target: number): number {
 }
 
 async function buildDimensionConfig(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const dimensionNames = await ZarrDataManager.getDimensionNames(
     props.datasources!,
@@ -659,8 +654,7 @@ async function buildDimensionConfig(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     excludedDims,
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
 }
 
@@ -689,13 +683,9 @@ function updateTileMaterials(rawData: Float32Array) {
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
-  const { dimensionRanges, indices } = await buildDimensionConfig(
-    datavar,
-    updateMode
-  );
+  const { dimensionRanges, indices } = await buildDimensionConfig(datavar);
 
   const rawData = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
@@ -727,8 +717,7 @@ async function fetchAndRenderData(
       bounds: { low: min, high: max },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
   redraw();
 }

--- a/src/ui/grids/Regular.vue
+++ b/src/ui/grids/Regular.vue
@@ -17,6 +17,7 @@ import {
 } from "./composables/useProjectionEdgeQuality.ts";
 import { useSharedGridLogic } from "./composables/useSharedGridLogic.ts";
 
+import { downsampleDataTexture } from "@/lib/data/dataTexture.ts";
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import {
@@ -52,6 +53,7 @@ const { paramDimIndices, paramDimMinBounds, paramDimMaxBounds } =
 
 const {
   getScene,
+  getRenderer,
   redraw,
   makeSnapshot,
   toggleRotate,
@@ -76,20 +78,11 @@ const { setHoverLookupFromIndex, clearHoverLookup } =
 
 const longitudes = ref(new Float64Array());
 const latitudes = ref(new Float64Array());
-const isLatReversed = ref(false);
 
 const BATCH_SIZE = 60;
-const MAX_TILE_SIZE = 4096;
-
-type TTileInfo = {
-  latStart: number;
-  latEnd: number;
-  lonStart: number;
-  lonEnd: number;
-};
+const MAX_GEO_RESOLUTION = 512;
 
 let meshes: THREE.Mesh[] = [];
-let tileInfos: TTileInfo[] = [];
 
 onColormapChange(() => updateColormap(meshes));
 
@@ -213,43 +206,43 @@ function isLongitudeGlobal(longitudes: Float64Array): boolean {
   return span + avgDelta > 359.5;
 }
 
-/**
- * Generates vertices, UVs, and lat/lon for a single 2D tile (lat band × lon band).
- * UVs are local to the tile's texture and point at texel centers.
- */
-function generateTileVerticesAndUVs(
+function generateBatchVerticesAndUVs(
   latitudes: Float64Array,
   longitudes: Float64Array,
+  latOrigIndices: Int32Array,
+  lonOrigIndices: Int32Array,
+  originalLatCount: number,
+  textureLonCount: number,
   latStart: number,
   latEnd: number,
-  lonStart: number,
-  lonEnd: number,
+  isLatReversed: boolean,
+  isRotated: boolean,
   poleLat?: number,
   poleLon?: number
 ) {
   const batchLatCount = latEnd - latStart + 1;
-  const tileLonCount = lonEnd - lonStart + 1;
-  const vertexCount = batchLatCount * tileLonCount;
+  const lonCount = longitudes.length;
+  const vertexCount = batchLatCount * lonCount;
 
   const positionValues = new Float32Array(vertexCount * 3);
   const uvs = new Float32Array(vertexCount * 2);
   const latLonValues = new Float32Array(vertexCount * 2);
+  const latDenominator = Math.max(originalLatCount - 1, 1);
 
   const helper = projectionHelper.value;
 
   for (let li = 0; li < batchLatCount; li++) {
     const globalLatIdx = latStart + li;
     const rawLat = latitudes[globalLatIdx];
-    for (let lj = 0; lj < tileLonCount; lj++) {
-      const globalLonIdx = lonStart + lj;
-      const rawLon = longitudes[globalLonIdx];
+    const latOrigIdx = latOrigIndices[globalLatIdx];
+    for (let lj = 0; lj < lonCount; lj++) {
+      const rawLon = longitudes[lj];
 
-      const { lat, lon } =
-        poleLat !== undefined
-          ? rotatedToGeographic(rawLat, rawLon, poleLat, poleLon!)
-          : { lat: rawLat, lon: rawLon };
+      const { lat, lon } = isRotated
+        ? rotatedToGeographic(rawLat, rawLon, poleLat!, poleLon!)
+        : { lat: rawLat, lon: rawLon };
 
-      const vertexIdx = li * tileLonCount + lj;
+      const vertexIdx = li * lonCount + lj;
       helper.projectLatLonToArrays(
         lat,
         lon,
@@ -259,8 +252,10 @@ function generateTileVerticesAndUVs(
         vertexIdx * 2
       );
 
-      const u = (lj + 0.5) / tileLonCount;
-      const v = (li + 0.5) / batchLatCount;
+      const u = (lonOrigIndices[lj] + 0.5) / textureLonCount;
+      const v = isLatReversed
+        ? (originalLatCount - 1 - latOrigIdx) / latDenominator
+        : latOrigIdx / latDenominator;
       uvs[vertexIdx * 2] = u;
       uvs[vertexIdx * 2 + 1] = v;
     }
@@ -270,9 +265,10 @@ function generateTileVerticesAndUVs(
 }
 
 function generateGridIndices(latCount: number, lonCount: number) {
-  const indices: number[] = [];
   const latIterationEnd = latCount - 1;
   const lonIterationEnd = lonCount - 1;
+  const indices = new Uint32Array(latIterationEnd * lonIterationEnd * 6);
+  let indexOffset = 0;
 
   for (let latIt = 0; latIt < latIterationEnd; latIt++) {
     for (let lonIt = 0; lonIt < lonIterationEnd; lonIt++) {
@@ -281,8 +277,12 @@ function generateGridIndices(latCount: number, lonCount: number) {
       const topLeft = (latIt + 1) * lonCount + lonIt;
       const topRight = (latIt + 1) * lonCount + lonIt + 1;
 
-      indices.push(lowLeft, topRight, topLeft);
-      indices.push(lowLeft, lowRight, topRight);
+      indices[indexOffset++] = lowLeft;
+      indices[indexOffset++] = topRight;
+      indices[indexOffset++] = topLeft;
+      indices[indexOffset++] = lowLeft;
+      indices[indexOffset++] = lowRight;
+      indices[indexOffset++] = topRight;
     }
   }
 
@@ -294,55 +294,119 @@ function normalizeLongitudes(longitudes: Float64Array): Float64Array {
   return Float64Array.from(longitudes, (lon) => ((lon % 360) + 360) % 360);
 }
 
-async function getGridParams() {
+function subsampleCoords(
+  values: Float64Array,
+  maxCount: number
+): { coords: Float64Array; origIndices: Int32Array } {
+  if (values.length <= maxCount) {
+    const origIndices = new Int32Array(values.length);
+    for (let i = 0; i < values.length; i++) {
+      origIndices[i] = i;
+    }
+    return { coords: values, origIndices };
+  }
+
+  const coords = new Float64Array(maxCount);
+  const origIndices = new Int32Array(maxCount);
+  for (let i = 0; i < maxCount; i++) {
+    const sourceIdx = Math.round((i * (values.length - 1)) / (maxCount - 1));
+    coords[i] = values[sourceIdx];
+    origIndices[i] = sourceIdx;
+  }
+  return { coords, origIndices };
+}
+
+async function getRegularGridParameters() {
   const isRotated = props.isRotated;
   let longitudeValues = normalizeLongitudes(longitudes.value);
   let latitudeValues = latitudes.value;
 
   // Check if latitudes are descending and reverse if necessary
-  const latReversed =
+  const isLatReversed =
     latitudeValues[0] > latitudeValues[latitudeValues.length - 1];
-  isLatReversed.value = latReversed;
-  if (latReversed) {
+  if (isLatReversed) {
     latitudeValues = Float64Array.from(latitudeValues).reverse();
   }
 
   const isGlobal = isLongitudeGlobal(longitudes.value);
+  const textureLonCount = longitudeValues.length;
+  const originalLatCount = latitudeValues.length;
 
+  const { coords: geoLatitudes, origIndices: latOrigIndices } = subsampleCoords(
+    latitudeValues,
+    MAX_GEO_RESOLUTION
+  );
+  const { coords: geoLongitudesBase, origIndices: lonOrigIndicesBase } =
+    subsampleCoords(longitudeValues, MAX_GEO_RESOLUTION);
+
+  let geoLongitudes = geoLongitudesBase;
+  let lonOrigIndices = lonOrigIndicesBase;
   if (isGlobal) {
-    // Add a duplicate of the first longitude + 360 to close the globe
-    const firstLon = longitudeValues[0];
-    longitudeValues = new Float64Array([...longitudeValues, firstLon + 360]);
+    geoLongitudes = new Float64Array([
+      ...geoLongitudesBase,
+      geoLongitudesBase[0] + 360,
+    ]);
+    lonOrigIndices = new Int32Array(lonOrigIndicesBase.length + 1);
+    lonOrigIndices.set(lonOrigIndicesBase);
+    lonOrigIndices[lonOrigIndicesBase.length] = textureLonCount;
   }
 
-  let poleLat, poleLon;
+  let poleLat: number | undefined, poleLon: number | undefined;
   if (isRotated) {
     const rotatedNorthPole = await getRotatedNorthPole();
     poleLat = rotatedNorthPole.lat;
     poleLon = rotatedNorthPole.lon;
   }
 
-  const latCount = latitudeValues.length;
-  const lonCount = longitudeValues.length;
-
   return {
-    latitudeValues,
-    longitudeValues,
-    latCount,
-    lonCount,
+    geoLatitudes,
+    geoLongitudes,
+    latOrigIndices,
+    lonOrigIndices,
+    originalLatCount,
+    textureLonCount,
+    isLatReversed,
+    isRotated,
     poleLat,
     poleLon,
+    geoLatCount: geoLatitudes.length,
+    geoLonCount: geoLongitudes.length,
   };
 }
 
-function disposeMeshMaterial(mesh: THREE.Mesh) {
-  const mat = mesh.material as THREE.ShaderMaterial;
-  if (mat && mat.dispose) {
-    if (mat.uniforms?.data?.value?.dispose) {
-      mat.uniforms.data.value.dispose();
-    }
-    mat.dispose();
+function disposeMaterial(material: THREE.Material) {
+  const shaderMaterial = material as THREE.ShaderMaterial;
+  if (shaderMaterial.uniforms?.data?.value?.dispose) {
+    shaderMaterial.uniforms.data.value.dispose();
   }
+  material.dispose();
+}
+
+function collectMeshMaterials(
+  mesh: THREE.Mesh,
+  materials: Set<THREE.Material>
+) {
+  if (Array.isArray(mesh.material)) {
+    for (const material of mesh.material) {
+      materials.add(material);
+    }
+    return;
+  }
+  materials.add(mesh.material);
+}
+
+function disposeMaterials(materials: Set<THREE.Material>) {
+  for (const material of materials) {
+    disposeMaterial(material);
+  }
+}
+
+function disposeMeshMaterials(targetMeshes: THREE.Mesh[]) {
+  const materials = new Set<THREE.Material>();
+  for (const mesh of targetMeshes) {
+    collectMeshMaterials(mesh, materials);
+  }
+  disposeMaterials(materials);
 }
 
 function cleanupMeshes(totalBatches: number) {
@@ -351,32 +415,33 @@ function cleanupMeshes(totalBatches: number) {
   }
   for (const mesh of meshes) {
     mesh.geometry.dispose();
-    disposeMeshMaterial(mesh);
     getScene()?.remove(mesh);
   }
+  disposeMeshMaterials(meshes);
   meshes.length = 0;
 }
 
-function createTileGeometry(
-  latitudeValues: Float64Array,
-  longitudeValues: Float64Array,
-  tile: TTileInfo,
-  poleLat?: number,
-  poleLon?: number
+function createBatchGeometry(
+  gridParams: Awaited<ReturnType<typeof getRegularGridParameters>>,
+  latStart: number,
+  latEnd: number
 ) {
   const geometry = new THREE.InstancedBufferGeometry();
-  const batchLatCount = tile.latEnd - tile.latStart + 1;
-  const tileLonCount = tile.lonEnd - tile.lonStart + 1;
+  const batchLatCount = latEnd - latStart + 1;
 
-  const { positionValues, uvs, latLonValues } = generateTileVerticesAndUVs(
-    latitudeValues,
-    longitudeValues,
-    tile.latStart,
-    tile.latEnd,
-    tile.lonStart,
-    tile.lonEnd,
-    poleLat,
-    poleLon
+  const { positionValues, uvs, latLonValues } = generateBatchVerticesAndUVs(
+    gridParams.geoLatitudes,
+    gridParams.geoLongitudes,
+    gridParams.latOrigIndices,
+    gridParams.lonOrigIndices,
+    gridParams.originalLatCount,
+    gridParams.textureLonCount,
+    latStart,
+    latEnd,
+    gridParams.isLatReversed,
+    gridParams.isRotated,
+    gridParams.poleLat,
+    gridParams.poleLon
   );
 
   geometry.setAttribute(
@@ -389,19 +454,19 @@ function createTileGeometry(
     new THREE.Float32BufferAttribute(latLonValues, 2)
   );
 
-  const indices = generateGridIndices(batchLatCount, tileLonCount);
-  geometry.setIndex(indices);
+  const indices = generateGridIndices(batchLatCount, gridParams.geoLonCount);
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
   return geometry;
 }
 
-function applyTileGeometry(
-  tileIndex: number,
+function applyBatchGeometry(
+  batchIndex: number,
   geometry: THREE.InstancedBufferGeometry
 ) {
-  if (meshes[tileIndex]) {
+  if (meshes[batchIndex]) {
     setupProjectionGeometryWrap(geometry);
-    meshes[tileIndex].geometry.dispose();
-    meshes[tileIndex].geometry = geometry;
+    meshes[batchIndex].geometry.dispose();
+    meshes[batchIndex].geometry = geometry;
   } else {
     const mesh = createWrappedProjectionMesh(
       geometry,
@@ -414,49 +479,20 @@ function applyTileGeometry(
   }
 }
 
-function computeTileLayout(latCount: number, geometryLonCount: number) {
-  const latBatchCount = Math.ceil((latCount - 1) / BATCH_SIZE);
-  const lonStep = MAX_TILE_SIZE - 1;
-  const lonTileCount = Math.max(1, Math.ceil((geometryLonCount - 1) / lonStep));
-  const actualLonStep = Math.ceil((geometryLonCount - 1) / lonTileCount);
-
-  const tiles: TTileInfo[] = [];
-  for (let latBatch = 0; latBatch < latBatchCount; latBatch++) {
-    const latStart = latBatch * BATCH_SIZE;
-    const latEnd = Math.min(latStart + BATCH_SIZE, latCount - 1);
-    for (let lonTile = 0; lonTile < lonTileCount; lonTile++) {
-      const lonStart = lonTile * actualLonStep;
-      const lonEnd = Math.min(lonStart + actualLonStep, geometryLonCount - 1);
-      tiles.push({ latStart, latEnd, lonStart, lonEnd });
-    }
-  }
-  return tiles;
-}
-
 async function makeGeometry() {
   try {
-    const {
-      latitudeValues,
-      longitudeValues,
-      latCount,
-      lonCount,
-      poleLat,
-      poleLon,
-    } = await getGridParams();
+    const gridParams = await getRegularGridParameters();
+    const totalBatches = Math.ceil((gridParams.geoLatCount - 1) / BATCH_SIZE);
+    cleanupMeshes(totalBatches);
 
-    const tiles = computeTileLayout(latCount, lonCount);
-    tileInfos = tiles;
-    cleanupMeshes(tiles.length);
-
-    for (let i = 0; i < tiles.length; i++) {
-      const geometry = createTileGeometry(
-        latitudeValues,
-        longitudeValues,
-        tiles[i],
-        poleLat,
-        poleLon
+    for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
+      const latStart = batchIndex * BATCH_SIZE;
+      const latEnd = Math.min(
+        latStart + BATCH_SIZE,
+        gridParams.geoLatCount - 1
       );
-      applyTileGeometry(i, geometry);
+      const geometry = createBatchGeometry(gridParams, latStart, latEnd);
+      applyBatchGeometry(batchIndex, geometry);
     }
     updateMeshProjectionUniforms();
   } catch (error) {
@@ -464,44 +500,68 @@ async function makeGeometry() {
   }
 }
 
-function createTileTexture(
-  rawData: Float32Array,
-  tile: TTileInfo,
-  textureLonCount: number,
-  totalLatCount: number,
-  isReversed: boolean,
-  latOnly: boolean
+function fitDataToMaxTextureSize(
+  data: Float32Array<ArrayBufferLike>,
+  sourceWidth: number,
+  sourceHeight: number
 ) {
-  const tileLatCount = tile.latEnd - tile.latStart + 1;
-  const tileLonCount = tile.lonEnd - tile.lonStart + 1;
-  const tileData = new Float32Array(tileLatCount * tileLonCount);
-
-  for (let li = 0; li < tileLatCount; li++) {
-    const fileLatIdx = isReversed
-      ? totalLatCount - 1 - (tile.latStart + li)
-      : tile.latStart + li;
-    if (latOnly) {
-      const val = rawData[fileLatIdx];
-      for (let lj = 0; lj < tileLonCount; lj++) {
-        tileData[li * tileLonCount + lj] = val;
-      }
-    } else {
-      for (let lj = 0; lj < tileLonCount; lj++) {
-        const globalLonIdx = (tile.lonStart + lj) % textureLonCount;
-        tileData[li * tileLonCount + lj] =
-          rawData[fileLatIdx * textureLonCount + globalLonIdx];
-      }
-    }
+  let texWidth = sourceWidth;
+  let texHeight = sourceHeight;
+  let textureData = data;
+  const maxTexSize = getRenderer()?.capabilities.maxTextureSize ?? 4096;
+  if (texWidth > maxTexSize || texHeight > maxTexSize) {
+    texWidth = Math.min(sourceWidth, maxTexSize);
+    texHeight = Math.min(sourceHeight, maxTexSize);
+    textureData = downsampleDataTexture(
+      data,
+      sourceWidth,
+      sourceHeight,
+      texWidth,
+      texHeight
+    );
   }
 
+  return { data: textureData, texWidth, texHeight };
+}
+
+function createLatOnlyTextureData(
+  rawData: Float32Array,
+  latCount: number,
+  lonCount: number
+) {
+  const data = new Float32Array(latCount * lonCount);
+  for (let latIdx = 0; latIdx < latCount; latIdx++) {
+    const value = rawData[latIdx];
+    for (let lonIdx = 0; lonIdx < lonCount; lonIdx++) {
+      data[latIdx * lonCount + lonIdx] = value;
+    }
+  }
+  return data;
+}
+
+function createRegularTexture(rawData: Float32Array, wrapRepeat: boolean) {
+  const latCount = latitudes.value.length;
+  const lonCount = longitudes.value.length;
+  const textureData = isLatOnly.value
+    ? createLatOnlyTextureData(rawData, latCount, lonCount)
+    : rawData;
+  const { data, texWidth, texHeight } = fitDataToMaxTextureSize(
+    textureData,
+    lonCount,
+    latCount
+  );
+
   const texture = new THREE.DataTexture(
-    tileData,
-    tileLonCount,
-    tileLatCount,
+    data,
+    texWidth,
+    texHeight,
     THREE.RedFormat,
     THREE.FloatType,
     THREE.UVMapping
   );
+  if (wrapRepeat) {
+    texture.wrapS = THREE.RepeatWrapping;
+  }
   texture.needsUpdate = true;
   return texture;
 }
@@ -516,7 +576,11 @@ async function getRotatedNorthPole(): Promise<{ lat: number; lon: number }> {
   return { lat, lon };
 }
 
-function makeTileMaterial(texture: THREE.DataTexture) {
+function makeMaterial(rawData: Float32Array) {
+  const texture = createRegularTexture(
+    rawData,
+    isLongitudeGlobal(longitudes.value)
+  );
   const low = store.selection?.low as number;
   const high = store.selection?.high as number;
   const { addOffset, scaleFactor } = getColormapScaleOffset(
@@ -658,28 +722,26 @@ async function buildDimensionConfig(
   );
 }
 
-function updateTileMaterials(rawData: Float32Array) {
-  const helper = projectionHelper.value;
-  const textureLonCount = longitudes.value.length;
-  const totalLatCount = latitudes.value.length;
-  const isReversed = isLatReversed.value;
-
-  for (let i = 0; i < meshes.length; i++) {
-    const tile = tileInfos[i];
-    const texture = createTileTexture(
-      rawData,
-      tile,
-      textureLonCount,
-      totalLatCount,
-      isReversed,
-      isLatOnly.value
-    );
-    const material = makeTileMaterial(texture);
-    updateProjectionUniforms(material, helper);
-    disposeMeshMaterial(meshes[i]);
-    meshes[i].material = material;
-    material.needsUpdate = true;
+function setMeshMaterials(material: THREE.ShaderMaterial) {
+  if (meshes.length === 0) {
+    disposeMaterial(material);
+    return;
   }
+
+  const previousMaterials = new Set<THREE.Material>();
+  for (const mesh of meshes) {
+    collectMeshMaterials(mesh, previousMaterials);
+    mesh.material = material;
+  }
+  previousMaterials.delete(material);
+  disposeMaterials(previousMaterials);
+  material.needsUpdate = true;
+}
+
+function updateMeshMaterials(rawData: Float32Array) {
+  const material = makeMaterial(rawData);
+  updateProjectionUniforms(material, projectionHelper.value);
+  setMeshMaterials(material);
 }
 
 async function fetchAndRenderData(
@@ -696,7 +758,7 @@ async function fetchAndRenderData(
     rawData
   );
 
-  updateTileMaterials(rawData);
+  updateMeshMaterials(rawData);
 
   const hoverIndex = await buildHoverSamples(rawData);
   setHoverLookupFromIndex(hoverIndex, fillValue, missingValue);
@@ -729,11 +791,10 @@ onBeforeMount(async () => {
 onBeforeUnmount(() => {
   for (const mesh of meshes) {
     mesh.geometry.dispose();
-    disposeMeshMaterial(mesh);
     getScene()?.remove(mesh);
   }
+  disposeMeshMaterials(meshes);
   meshes.length = 0;
-  tileInfos.length = 0;
 });
 
 defineExpose({

--- a/src/ui/grids/Triangular.vue
+++ b/src/ui/grids/Triangular.vue
@@ -25,11 +25,7 @@ import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import { makeInvertableGpuMeshMaterial } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 import { useLog } from "@/utils/logging.ts";
 
 const props = defineProps<{
@@ -354,8 +350,7 @@ function distributeDataToMeshes(dataBuffer: {
 }
 
 async function buildDimensionConfig(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
   const dimensionNames = await ZarrDataManager.getDimensionNames(
     props.datasources!,
@@ -369,19 +364,14 @@ async function buildDimensionConfig(
     paramDimMaxBounds.value,
     dimSlidersValues.value.length > 0 ? dimSlidersValues.value : null,
     [datavar.shape.length - 1],
-    varinfo.value?.dimRanges,
-    updateMode === UPDATE_MODE.SLIDER_TOGGLE
+    varinfo.value?.dimRanges
   );
 }
 
 async function fetchAndRenderData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  updateMode: TUpdateMode
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
 ) {
-  const { dimensionRanges, indices } = await buildDimensionConfig(
-    datavar,
-    updateMode
-  );
+  const { dimensionRanges, indices } = await buildDimensionConfig(datavar);
 
   const rawData = await ZarrDataManager.getVariableDataFromArray(
     datavar,
@@ -421,8 +411,7 @@ async function fetchAndRenderData(
       bounds: { low: dataBuffer.dataMin, high: dataBuffer.dataMax },
       dimRanges: dimensionRanges,
     },
-    indices as number[],
-    updateMode
+    indices as number[]
   );
   redraw();
 }

--- a/src/ui/grids/composables/useGridDataLoader.ts
+++ b/src/ui/grids/composables/useGridDataLoader.ts
@@ -2,11 +2,7 @@ import { ref, watch, type Ref } from "vue";
 import type * as zarr from "zarrita";
 
 import type { TSources } from "@/lib/types/GlobeTypes.ts";
-import {
-  UPDATE_MODE,
-  useGlobeControlStore,
-  type TUpdateMode,
-} from "@/store/store.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
 import { useLog } from "@/utils/logging.ts";
 
 type TDataVar = zarr.Array<zarr.DataType, zarr.AsyncReadable>;
@@ -24,10 +20,7 @@ type TGridDataLoaderOptions = {
     varname: string,
     datasources: TSources
   ) => Promise<TDataVar | undefined>;
-  fetchAndRenderData: (
-    datavar: TDataVar,
-    updateMode: TUpdateMode
-  ) => Promise<void>;
+  fetchAndRenderData: (datavar: TDataVar) => Promise<void>;
   clearHoverLookup: () => void;
   updateLandSeaMask: () => void | Promise<void>;
   updateColormap: () => void;
@@ -43,9 +36,7 @@ function createGetData(
   state: TLoaderState,
   logError: TLogError
 ) {
-  return async function getData(
-    updateMode: TUpdateMode = UPDATE_MODE.INITIAL_LOAD
-  ) {
+  return async function getData() {
     const datasources = options.getDatasources();
     if (!datasources) {
       return;
@@ -66,7 +57,7 @@ function createGetData(
           datasources
         );
         if (datavar !== undefined) {
-          await options.fetchAndRenderData(datavar, updateMode);
+          await options.fetchAndRenderData(datavar);
         }
       } while (state.pendingUpdate.value);
     } catch (error) {
@@ -80,7 +71,7 @@ function createGetData(
 
 function createDatasourceUpdate(
   options: TGridDataLoaderOptions,
-  getData: (updateMode?: TUpdateMode) => Promise<void>
+  getData: () => Promise<void>
 ) {
   return async function datasourceUpdate() {
     options.resetDataVars?.();
@@ -100,7 +91,7 @@ function createDatasourceUpdate(
 function registerGridDataLoaderWatches(
   options: TGridDataLoaderOptions,
   store: TGlobeControlStore,
-  getData: (updateMode?: TUpdateMode) => Promise<void>,
+  getData: () => Promise<void>,
   datasourceUpdate: () => Promise<void>
 ) {
   watch(
@@ -115,10 +106,12 @@ function registerGridDataLoaderWatches(
     () => store.dimSlidersValues,
     async () => {
       if (store.isInitializingVariable) {
+        // when variable changes, we fetch data in the varnameSelector watcher,
+        // and we don't want to fetch data twice
         store.isInitializingVariable = false;
         return;
       }
-      await getData(UPDATE_MODE.SLIDER_TOGGLE);
+      await getData();
       options.updateColormap();
     },
     { deep: true }

--- a/src/ui/grids/composables/useGridHistogram.ts
+++ b/src/ui/grids/composables/useGridHistogram.ts
@@ -77,6 +77,7 @@ export function useGridHistogram() {
     if (!data || data.length === 0 || !isFinite(min) || !isFinite(max)) {
       store.updateHistogram(undefined);
       store.updateFullHistogram(undefined);
+      store.updateHistogramSummary(undefined);
       lastHistogramSummary.value = null;
       return;
     }
@@ -107,6 +108,7 @@ export function useGridHistogram() {
       max
     );
     store.updateFullHistogram(fullHist);
+    store.updateHistogramSummary(summary);
 
     recomputeHistogramFromSummary(
       summary,

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -1154,6 +1154,7 @@ export function useGridScene(options: UseGridSceneOptions) {
     box,
     getScene,
     getCamera,
+    getRenderer,
     redraw,
     toggleRotate,
     makeSnapshot,

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -77,6 +77,8 @@ export function useGridScene(options: UseGridSceneOptions) {
   const raycaster = new THREE.Raycaster();
   const hoveredGeoPoint = shallowRef<THoverGeoPoint | null>(null);
   let lastPointerPosition: { clientX: number; clientY: number } | null = null;
+  let touchPickStart: { clientX: number; clientY: number } | null = null;
+  let touchPickMoved = false;
 
   let projectionDragActive = false;
   let dragStartX = 0;
@@ -100,6 +102,7 @@ export function useGridScene(options: UseGridSceneOptions) {
   const FLAT_CROP_RENDER_ORDER = 5;
   const FLAT_CROP_Z_OFFSET = 0.06;
   const FLAT_BOUNDARY_STEP_DEGREES = 0.25;
+  const TOUCH_PICK_TAP_MAX_DISTANCE_PX = 10;
   let targetOffset = 0;
   let isInitialLoad = true;
   let isInMotion = false;
@@ -889,22 +892,70 @@ export function useGridScene(options: UseGridSceneOptions) {
     animationLoop();
   }
 
+  function updateHoverPosition(clientX: number, clientY: number) {
+    if (!isHoverActive()) {
+      return;
+    }
+    lastPointerPosition = { clientX, clientY };
+    refreshHover();
+  }
+
+  function onTouchPickStart(event: TouchEvent) {
+    const touch = event.touches[0];
+    touchPickStart =
+      event.touches.length === 1 && touch
+        ? { clientX: touch.clientX, clientY: touch.clientY }
+        : null;
+    touchPickMoved = false;
+  }
+
+  function onTouchPickMove(event: TouchEvent) {
+    const touch = event.touches[0];
+    if (!touchPickStart || !touch) {
+      return;
+    }
+    const deltaX = touch.clientX - touchPickStart.clientX;
+    const deltaY = touch.clientY - touchPickStart.clientY;
+    if (
+      deltaX * deltaX + deltaY * deltaY >
+      TOUCH_PICK_TAP_MAX_DISTANCE_PX * TOUCH_PICK_TAP_MAX_DISTANCE_PX
+    ) {
+      touchPickMoved = true;
+    }
+  }
+
+  function onTouchPickEnd(event: TouchEvent) {
+    const touch = event.changedTouches[0];
+    if (!touchPickStart || touchPickMoved || !touch) {
+      touchPickStart = null;
+      return;
+    }
+    updateHoverPosition(touch.clientX, touch.clientY);
+    touchPickStart = null;
+  }
+
   function setupHoverListeners() {
     useEventListener(
       canvas.value,
       "mousemove",
       (event: MouseEvent) => {
-        if (!isHoverActive()) {
-          return;
-        }
-        lastPointerPosition = {
-          clientX: event.clientX,
-          clientY: event.clientY,
-        };
-        refreshHover();
+        updateHoverPosition(event.clientX, event.clientY);
       },
       { passive: true }
     );
+
+    useEventListener(canvas.value, "touchstart", onTouchPickStart, {
+      passive: true,
+    });
+    useEventListener(canvas.value, "touchmove", onTouchPickMove, {
+      passive: true,
+    });
+    useEventListener(canvas.value, "touchend", onTouchPickEnd, {
+      passive: true,
+    });
+    useEventListener(canvas.value, "touchcancel", () => {
+      touchPickStart = null;
+    });
 
     useEventListener(
       canvas.value,

--- a/src/ui/grids/composables/useGridSnapshot.ts
+++ b/src/ui/grids/composables/useGridSnapshot.ts
@@ -23,6 +23,115 @@ type UseGridSnapshotOptions = {
   render: () => boolean;
 };
 
+type TSnapshotRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const FLAT_BACKGROUND_SCALE = 1.05;
+const GLOBE_SNAPSHOT_RADIUS = 1;
+
+function getFullSnapshotRect(w: number, h: number): TSnapshotRect {
+  return { x: 0, y: 0, width: w, height: h };
+}
+
+function clampSnapshotRect(
+  rect: TSnapshotRect,
+  w: number,
+  h: number
+): TSnapshotRect {
+  const x1 = Math.max(0, Math.min(w, Math.floor(rect.x)));
+  const y1 = Math.max(0, Math.min(h, Math.floor(rect.y)));
+  const x2 = Math.max(0, Math.min(w, Math.ceil(rect.x + rect.width)));
+  const y2 = Math.max(0, Math.min(h, Math.ceil(rect.y + rect.height)));
+
+  if (x2 <= x1 || y2 <= y1) {
+    return getFullSnapshotRect(w, h);
+  }
+
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+}
+
+function getProjectedPointsRect(
+  points: THREE.Vector3[],
+  camera: THREE.PerspectiveCamera,
+  w: number,
+  h: number
+) {
+  const projectedPoints = points.map((point) => point.clone().project(camera));
+  const xs = projectedPoints.map((point) => ((point.x + 1) / 2) * w);
+  const ys = projectedPoints.map((point) => ((1 - point.y) / 2) * h);
+
+  return clampSnapshotRect(
+    {
+      x: Math.min(...xs),
+      y: Math.min(...ys),
+      width: Math.max(...xs) - Math.min(...xs),
+      height: Math.max(...ys) - Math.min(...ys),
+    },
+    w,
+    h
+  );
+}
+
+function getSnapshotContentRect(
+  camera: THREE.PerspectiveCamera,
+  baseSurface: THREE.Mesh | undefined,
+  w: number,
+  h: number
+): TSnapshotRect {
+  if (!baseSurface) {
+    return getFullSnapshotRect(w, h);
+  }
+
+  camera.updateMatrixWorld(true);
+  baseSurface.updateWorldMatrix(true, false);
+
+  const plane = baseSurface.geometry as THREE.PlaneGeometry;
+  if (plane.parameters?.width && plane.parameters?.height) {
+    const halfWidth = plane.parameters.width / (2 * FLAT_BACKGROUND_SCALE);
+    const halfHeight = plane.parameters.height / (2 * FLAT_BACKGROUND_SCALE);
+    const points = [
+      new THREE.Vector3(-halfWidth, -halfHeight, 0),
+      new THREE.Vector3(halfWidth, -halfHeight, 0),
+      new THREE.Vector3(halfWidth, halfHeight, 0),
+      new THREE.Vector3(-halfWidth, halfHeight, 0),
+    ].map((point) => point.applyMatrix4(baseSurface.matrixWorld));
+
+    return getProjectedPointsRect(points, camera, w, h);
+  }
+
+  const center = new THREE.Vector3().setFromMatrixPosition(
+    baseSurface.matrixWorld
+  );
+  const distance = camera.position.distanceTo(center);
+  if (distance <= GLOBE_SNAPSHOT_RADIUS) {
+    return getFullSnapshotRect(w, h);
+  }
+
+  const centerProjected = center.clone().project(camera);
+  const angularRadius = Math.asin(GLOBE_SNAPSHOT_RADIUS / distance);
+  const vHalfFov = THREE.MathUtils.degToRad(camera.fov / 2);
+  const hHalfFov = Math.atan(Math.tan(vHalfFov) * camera.aspect);
+  const halfWidth = (Math.tan(angularRadius) / Math.tan(hHalfFov)) * (w / 2);
+  const halfHeight = (Math.tan(angularRadius) / Math.tan(vHalfFov)) * (h / 2);
+  const centerX = ((centerProjected.x + 1) / 2) * w;
+  const centerY = ((1 - centerProjected.y) / 2) * h;
+
+  return clampSnapshotRect(
+    {
+      x: centerX - halfWidth,
+      y: centerY - halfHeight,
+      width: halfWidth * 2,
+      height: halfHeight * 2,
+    },
+    w,
+    h
+  );
+}
+
 /* eslint-disable-next-line max-lines-per-function */
 export function useGridSnapshot(deps: UseGridSnapshotOptions) {
   const { canvas, getRenderer, getScene, getCamera, getBaseSurface, render } =
@@ -233,24 +342,23 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
   /** Draw colormap gradient bar + value labels onto the composite canvas. */
   function drawColormapSection(
     ctx: CanvasRenderingContext2D,
-    w: number,
+    x: number,
+    width: number,
     y: number,
-    margin: number,
     barHeight: number,
     labelFontSize: number,
     textColor: string
   ) {
-    const cmWidth = w - 2 * margin;
     const cmCanvas = renderColormapGradient(
       store.colormap,
       store.invertColormap ? 1 : 0,
       store.invertColormap ? -1 : 1,
       store.posterizeLevels,
-      cmWidth,
+      width,
       barHeight
     );
     if (cmCanvas) {
-      ctx.drawImage(cmCanvas, margin, y, cmWidth, barHeight);
+      ctx.drawImage(cmCanvas, x, y, width, barHeight);
     }
     ctx.fillStyle = textColor;
     ctx.font = `${labelFontSize}px sans-serif`;
@@ -258,10 +366,24 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
     const sel = store.selection as { low?: number; high?: number };
     if (sel.low !== undefined && sel.high !== undefined) {
       ctx.textAlign = "left";
-      ctx.fillText(formatSnapValue(sel.low), margin, y + barHeight + 3);
+      ctx.fillText(formatSnapValue(sel.low), x, y + barHeight + 3);
       ctx.textAlign = "right";
-      ctx.fillText(formatSnapValue(sel.high), w - margin, y + barHeight + 3);
+      ctx.fillText(formatSnapValue(sel.high), x + width, y + barHeight + 3);
     }
+  }
+
+  function downloadSnapshot(composite: HTMLCanvasElement) {
+    composite.toBlob((blob) => {
+      if (!blob) {
+        logError("Failed to create snapshot blob");
+        return;
+      }
+      const link = document.createElement("a");
+      link.download = "gridlook.png";
+      link.href = URL.createObjectURL(blob!);
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, "image/png");
   }
 
   /** Draw overlays (colormap bar + info text) onto the composite canvas, then trigger download. */
@@ -269,8 +391,8 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
   function drawOverlaysAndDownload(
     composite: HTMLCanvasElement,
     ctx: CanvasRenderingContext2D,
-    w: number,
-    h: number,
+    imageHeight: number,
+    overlayRect: TSnapshotRect,
     showColormap: boolean,
     datasetTitle: string | null,
     infoLines: string[],
@@ -281,13 +403,13 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
     fontSize: number,
     textColor: string
   ) {
-    let currentY = h + margin;
+    let currentY = imageHeight + margin;
     if (showColormap) {
       drawColormapSection(
         ctx,
-        w,
+        overlayRect.x,
+        overlayRect.width,
         currentY,
-        margin,
         cmBarH,
         Math.round(fontSize * 0.85),
         textColor
@@ -295,11 +417,10 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
       currentY += cmBarH + cmLabelH;
     }
     if (datasetTitle !== null) {
-      const maxWidth = w - 2 * margin;
       const { height: titleHeight } = canvasTxtDrawText(ctx, datasetTitle, {
-        x: margin,
+        x: overlayRect.x,
         y: currentY,
-        width: maxWidth,
+        width: overlayRect.width,
         height: infoLineH * 10,
         fontSize,
         align: "left",
@@ -314,21 +435,11 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
       ctx.textBaseline = "top";
       ctx.textAlign = "left";
       for (const line of infoLines) {
-        ctx.fillText(line, margin, currentY);
+        ctx.fillText(line, overlayRect.x, currentY);
         currentY += infoLineH;
       }
     }
-    composite.toBlob((blob) => {
-      if (!blob) {
-        logError("Failed to create snapshot blob");
-        return;
-      }
-      const link = document.createElement("a");
-      link.download = "gridlook.png";
-      link.href = URL.createObjectURL(blob!);
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }, "image/png");
+    downloadSnapshot(composite);
   }
 
   function fillBackground(
@@ -357,6 +468,40 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
       options.resolutionScale
     );
     const { background, showDatasetInfo, showColormap } = options;
+    const contentRect = getSnapshotContentRect(
+      getCamera()!,
+      getBaseSurface(),
+      w,
+      h
+    );
+    const noOverlays = !showColormap && !showDatasetInfo;
+
+    if (noOverlays) {
+      const composite = document.createElement("canvas");
+      composite.width = contentRect.width;
+      composite.height = contentRect.height;
+      const ctx = composite.getContext("2d")!;
+      const imageCanvas = document.createElement("canvas");
+      imageCanvas.width = w;
+      imageCanvas.height = h;
+      const imageCtx = imageCanvas.getContext("2d")!;
+
+      fillBackground(imageCtx, w, h, background);
+      renderGlobeToCtx(imageCtx, w, h, background);
+      ctx.drawImage(
+        imageCanvas,
+        contentRect.x,
+        contentRect.y,
+        contentRect.width,
+        contentRect.height,
+        0,
+        0,
+        contentRect.width,
+        contentRect.height
+      );
+      downloadSnapshot(composite);
+      return;
+    }
 
     const fontSize = Math.round(Math.max(13, h * 0.022));
     const MARGIN = Math.round(Math.max(10, h * 0.018));
@@ -369,7 +514,7 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
       buildSnapshotInfoLines(showDatasetInfo);
 
     // Estimate wrapped title height to size the composite canvas correctly.
-    const maxTextWidth = w - 2 * MARGIN;
+    const maxTextWidth = contentRect.width;
     let titleLines = 1;
     if (datasetTitle) {
       const measCanvas = document.createElement("canvas");
@@ -399,8 +544,8 @@ export function useGridSnapshot(deps: UseGridSnapshotOptions) {
     drawOverlaysAndDownload(
       composite,
       ctx,
-      w,
       h,
+      contentRect,
       showColormap,
       datasetTitle,
       infoLines,

--- a/src/ui/grids/composables/useSharedGridLogic.ts
+++ b/src/ui/grids/composables/useSharedGridLogic.ts
@@ -68,6 +68,7 @@ export function useSharedGridLogic() {
     box,
     getScene,
     getCamera,
+    getRenderer,
     redraw,
     toggleRotate,
     makeSnapshot,
@@ -201,6 +202,7 @@ export function useSharedGridLogic() {
   return {
     getScene,
     getCamera,
+    getRenderer,
     redraw,
     toggleRotate,
     makeSnapshot,

--- a/src/ui/overlays/AboutModal.vue
+++ b/src/ui/overlays/AboutModal.vue
@@ -1,9 +1,26 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import QRCode from "qrcode";
+import { nextTick, ref, watch } from "vue";
 
 import Modal from "@/ui/common/Modal.vue";
 
 const visible = ref(false);
+const repoQrCanvas = ref<HTMLCanvasElement | null>(null);
+const pageQrCanvas = ref<HTMLCanvasElement | null>(null);
+
+function generateQR(canvas: HTMLCanvasElement | null, url: string) {
+  if (canvas) {
+    void QRCode.toCanvas(canvas, url, { width: 150 });
+  }
+}
+
+watch(visible, async (newVal) => {
+  if (newVal) {
+    await nextTick();
+    generateQR(repoQrCanvas.value, "https://github.com/d70-t/gridlook");
+    generateQR(pageQrCanvas.value, "https://gridlook.pages.dev");
+  }
+});
 </script>
 
 <template>
@@ -13,6 +30,28 @@ const visible = ref(false);
       supports cloud-hosted Zarr datasets and provides interactive grid
       visualization tools.
     </p>
+    <div class="columns is-mobile mt-3">
+      <div class="column has-text-centered">
+        <p class="has-text-weight-semibold">Application</p>
+        <canvas
+          ref="pageQrCanvas"
+          role="img"
+          aria-label="QR code for the Gridlook application"
+        >
+          QR code for the Gridlook application.
+        </canvas>
+      </div>
+      <div class="column has-text-centered">
+        <p class="has-text-weight-semibold">GitHub</p>
+        <canvas
+          ref="repoQrCanvas"
+          role="img"
+          aria-label="QR code for the Gridlook GitHub repository"
+        >
+          QR code for the Gridlook GitHub repository.
+        </canvas>
+      </div>
+    </div>
     <br />
     <p>
       Developed by Max-Planck-Institute for Meteorology (MPI-M) and the German

--- a/src/ui/overlays/Controls.vue
+++ b/src/ui/overlays/Controls.vue
@@ -1,7 +1,17 @@
 <script lang="ts" setup>
 import { useEventListener } from "@vueuse/core";
 import { storeToRefs } from "pinia";
-import { computed, onBeforeMount, onMounted, ref, watch, type Ref } from "vue";
+import {
+  computed,
+  onBeforeMount,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch,
+  type Ref,
+} from "vue";
+
+import CollapsibleCard from "../common/CollapsibleCard.vue";
 
 import ActionControls from "./controls/ActionControls.vue";
 import BoundsControls from "./controls/BoundsControls.vue";
@@ -322,53 +332,50 @@ onMounted(() => {
     </div>
   </div>
 
-  <template v-if="modelInfo">
-    <Transition name="slide">
-      <nav v-show="!isHidden" id="main_controls" class="gl_controls">
-        <div class="full-panel">
-          <div class="box m-2 p-2">
-            <div class="section-title">Variable</div>
-            <VariableSelector
-              v-model="varnameSelector"
-              :model-info="modelInfo"
-            />
-            <DimensionControl />
-          </div>
-          <div class="box m-2 p-2">
-            <div class="section-title">Colormap</div>
-            <BoundsControls
-              :picked-bounds-mode="pickedBoundsMode"
-              :data-bounds="dataBounds"
-              :default-bounds="defaultBounds"
-              :current-bounds="currentBounds"
-              :bound-modes="BOUND_MODES"
-              @update:picked-bounds-mode="
-                onPickedBoundsModeChange($event as TBoundModes)
-              "
-            />
-            <ColormapControls
-              :model-info="modelInfo"
-              :data-bounds="dataBounds"
-              @colormap-user-selected="userHasSelectedColormap = true"
-              @force-user-bounds="pickedBoundsMode = BOUND_MODES.USER"
-            />
-            <div class="section-title mt-2">Projections</div>
-            <ProjectionControls />
-            <div class="section-title">Masks</div>
-            <MaskControls />
-          </div>
-          <div class="box m-2 p-2">
-            <div class="section-title">Actions</div>
-            <ActionControls
-              @on-snapshot="(opts) => $emit('onSnapshot', opts)"
-              @on-rotate="() => $emit('onRotate')"
-              @toggle-display="() => $emit('toggleDisplay')"
-            />
-          </div>
-        </div>
-      </nav>
-    </Transition>
-  </template>
+  <Transition name="slide">
+    <nav v-show="!isHidden && modelInfo" id="main_controls" class="gl_controls">
+      <div class="full-panel">
+        <CollapsibleCard title="Variable">
+          <VariableSelector
+            v-if="modelInfo"
+            v-model="varnameSelector"
+            :model-info="modelInfo"
+          />
+          <DimensionControl />
+        </CollapsibleCard>
+
+        <CollapsibleCard title="Appearance">
+          <div class="section-title">Colormap</div>
+          <BoundsControls
+            :picked-bounds-mode="pickedBoundsMode"
+            :data-bounds="dataBounds"
+            :bound-modes="BOUND_MODES"
+            @update:picked-bounds-mode="
+              onPickedBoundsModeChange($event as TBoundModes)
+            "
+          />
+          <ColormapControls
+            v-if="modelInfo"
+            :model-info="modelInfo"
+            :data-bounds="dataBounds"
+            @colormap-user-selected="userHasSelectedColormap = true"
+            @force-user-bounds="pickedBoundsMode = BOUND_MODES.USER"
+          />
+          <div class="section-title mt-2">Projections</div>
+          <ProjectionControls />
+          <div class="section-title">Masks</div>
+          <MaskControls />
+        </CollapsibleCard>
+        <CollapsibleCard title="Actions">
+          <ActionControls
+            @on-snapshot="(opts) => $emit('onSnapshot', opts)"
+            @on-rotate="() => $emit('onRotate')"
+            @toggle-display="() => $emit('toggleDisplay')"
+          />
+        </CollapsibleCard>
+      </div>
+    </nav>
+  </Transition>
 </template>
 
 <style lang="scss">
@@ -384,16 +391,6 @@ onMounted(() => {
 
 .panel-toggle {
   order: 2;
-}
-
-.section-title {
-  font-weight: 700 !important;
-  text-transform: uppercase !important;
-  font-size: 0.75rem !important;
-  padding-right: 0.5rem !important;
-  padding-left: 0.5rem !important;
-  padding-top: 0.5rem !important;
-  color: var(--bulma-grey) !important;
 }
 
 .header-container {

--- a/src/ui/overlays/Controls.vue
+++ b/src/ui/overlays/Controls.vue
@@ -59,7 +59,6 @@ const {
 
 // Bounds logic state
 const pickedBoundsMode = ref<TBoundModes>(BOUND_MODES.DATA);
-const defaultBounds = ref<TBounds>({});
 // True until the varnameSelector watcher fires for the first time.
 // Used to preserve URL-provided bounds on first load.
 const isInitialVarLoad = ref(true);

--- a/src/ui/overlays/Controls.vue
+++ b/src/ui/overlays/Controls.vue
@@ -1,15 +1,7 @@
 <script lang="ts" setup>
 import { useEventListener } from "@vueuse/core";
 import { storeToRefs } from "pinia";
-import {
-  computed,
-  onBeforeMount,
-  onMounted,
-  onUnmounted,
-  ref,
-  watch,
-  type Ref,
-} from "vue";
+import { computed, onBeforeMount, ref, watch, type Ref } from "vue";
 
 import CollapsibleCard from "../common/CollapsibleCard.vue";
 
@@ -37,7 +29,10 @@ import { useUrlParameterStore } from "@/store/paramStore.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
 import { MOBILE_BREAKPOINT } from "@/ui/common/viewConstants.ts";
 
-const props = defineProps<{ modelInfo?: TModelInfo; currentSource: string }>();
+const props = defineProps<{
+  modelInfo?: TModelInfo;
+  currentSource: string;
+}>();
 
 defineEmits<{
   onSnapshot: [options: TSnapshotOptions];
@@ -69,9 +64,6 @@ const {
 
 // Bounds logic state
 const pickedBoundsMode = ref<TBoundModes>(BOUND_MODES.DATA);
-// True until the varnameSelector watcher fires for the first time.
-// Used to preserve URL-provided bounds on first load.
-const isInitialVarLoad = ref(true);
 
 // Colormap logic state
 const userHasSelectedColormap = ref<boolean>(false);
@@ -103,17 +95,17 @@ const currentBounds = computed(() => {
   if (pickedBoundsMode.value === BOUND_MODES.DATA) {
     return dataBounds.value;
   } else if (pickedBoundsMode.value === BOUND_MODES.USER) {
-    const lowEmpty =
+    const isLowEmpty =
       userBoundsLow.value === undefined ||
       (userBoundsLow.value as unknown as string) === "";
-    const highEmpty =
+    const isHighEmpty =
       userBoundsHigh.value === undefined ||
       (userBoundsHigh.value as unknown as string) === "";
     const lo = (
-      lowEmpty ? dataBounds.value.low : userBoundsLow.value
+      isLowEmpty ? dataBounds.value.low : userBoundsLow.value
     ) as number;
     const hi = (
-      highEmpty ? dataBounds.value.high : userBoundsHigh.value
+      isHighEmpty ? dataBounds.value.high : userBoundsHigh.value
     ) as number;
     // Always deliver a normalised (non-inverted) range downstream so that
     // nothing breaks when the user types high < low.  The BoundsControls
@@ -158,10 +150,9 @@ watch(
     // default_range config.  On subsequent variable changes we always want to
     // reset to the new variable's defaults.
     const preserveUrlBounds =
-      isInitialVarLoad.value &&
+      store.isNewDataset() &&
       userBoundsLow.value !== undefined &&
       userBoundsHigh.value !== undefined;
-    isInitialVarLoad.value = false;
 
     if (!preserveUrlBounds) {
       store.resetUserBounds();
@@ -186,6 +177,15 @@ watch(
     store.updateBounds(currentBounds.value as TBounds);
   },
   { deep: true }
+);
+
+watch(
+  () => store.newDatasetSignifier,
+  () => {
+    if (store.isNewDataset()) {
+      init();
+    }
+  }
 );
 
 function onPickedBoundsModeChange(newMode: TBoundModes) {
@@ -223,54 +223,25 @@ onBeforeMount(() => {
   });
 });
 
-// INITIALIZATION
-if (paramMaskingUseTexture.value) {
-  if (paramMaskingUseTexture.value === "false") {
-    landSeaMaskUseTexture.value = false;
-  } else if (paramMaskingUseTexture.value === "true") {
-    landSeaMaskUseTexture.value = true;
-  }
-}
-
-if (paramMaskMode.value) {
-  landSeaMaskChoice.value =
-    paramMaskMode.value as typeof landSeaMaskChoice.value;
-}
-
-if (paramProjection.value) {
-  const projection = paramProjection.value as TProjectionType;
-  if (Object.values(PROJECTION_TYPES).includes(projection)) {
-    store.projectionMode = projection;
-  }
-}
-
-if (paramProjectionCenterLat.value || paramProjectionCenterLon.value) {
-  const lat = parseFloat(paramProjectionCenterLat.value ?? "0");
-  const lon = parseFloat(paramProjectionCenterLon.value ?? "0");
-  projectionCenter.value = {
-    lat: clamp(lat, -90, 90),
-    lon: clamp(lon, -180, 180),
-  };
-}
-
-if (paramBoundHigh.value && paramBoundLow.value) {
-  const low = parseFloat(paramBoundLow.value);
-  const high = parseFloat(paramBoundHigh.value);
-  userBoundsLow.value = low;
-  userBoundsHigh.value = high;
-  pickedBoundsMode.value = BOUND_MODES.USER;
-}
-
-// Initialize bounds and colormap when component mounts
-onMounted(() => {
+function init() {
   setDefaultBounds();
   store.updateBounds(currentBounds.value as TBounds);
 
+  // Initialize control panel visibility
+  const initiallyVisible = isMobileView.value
+    ? !mobileMenuCollapsed.value
+    : !menuCollapsed.value;
+  store.setControlPanelVisible(initiallyVisible);
+
+  initFromParams();
+}
+
+// eslint-disable-next-line max-lines-per-function
+function initFromParams() {
   if (paramColormap.value) {
     colormap.value = paramColormap.value;
     userHasSelectedColormap.value = true;
   }
-
   if (paramInvertColormap.value) {
     // explicitely check for string values "true" and "false"
     if (paramInvertColormap.value === "false") {
@@ -279,24 +250,48 @@ onMounted(() => {
       invertColormap.value = true;
     }
   }
-
   if (paramPosterizeLevels.value) {
     const levels = Number(paramPosterizeLevels.value);
     if (!isNaN(levels) && levels >= 0 && levels <= 32) {
       posterizeLevels.value = levels;
     }
   }
-
   if (paramHideLowerBound.value === "true") {
     store.hideLowerBound = true;
   }
-
-  // Initialize control panel visibility
-  const initiallyVisible = isMobileView.value
-    ? !mobileMenuCollapsed.value
-    : !menuCollapsed.value;
-  store.setControlPanelVisible(initiallyVisible);
-});
+  if (paramMaskingUseTexture.value) {
+    if (paramMaskingUseTexture.value === "false") {
+      landSeaMaskUseTexture.value = false;
+    } else if (paramMaskingUseTexture.value === "true") {
+      landSeaMaskUseTexture.value = true;
+    }
+  }
+  if (paramMaskMode.value) {
+    landSeaMaskChoice.value =
+      paramMaskMode.value as typeof landSeaMaskChoice.value;
+  }
+  if (paramProjection.value) {
+    const projection = paramProjection.value as TProjectionType;
+    if (Object.values(PROJECTION_TYPES).includes(projection)) {
+      store.projectionMode = projection;
+    }
+  }
+  if (paramProjectionCenterLat.value || paramProjectionCenterLon.value) {
+    const lat = parseFloat(paramProjectionCenterLat.value ?? "0");
+    const lon = parseFloat(paramProjectionCenterLon.value ?? "0");
+    projectionCenter.value = {
+      lat: clamp(lat, -90, 90),
+      lon: clamp(lon, -180, 180),
+    };
+  }
+  if (paramBoundHigh.value && paramBoundLow.value) {
+    const low = parseFloat(paramBoundLow.value);
+    const high = parseFloat(paramBoundHigh.value);
+    userBoundsLow.value = low;
+    userBoundsHigh.value = high;
+    pickedBoundsMode.value = BOUND_MODES.USER;
+  }
+}
 </script>
 
 <template>

--- a/src/ui/overlays/HoverReadout.vue
+++ b/src/ui/overlays/HoverReadout.vue
@@ -5,6 +5,7 @@ import {
   HOVERED_GRID_POINT_STATUS,
   useGlobeControlStore,
 } from "@/store/store.ts";
+import { formatValue } from "@/utils/formatValue";
 
 const store = useGlobeControlStore();
 const { hoveredGridPoint } = storeToRefs(store);
@@ -28,9 +29,11 @@ function formatCoordinate(value: number) {
     <span class="grid-hover-separator">&bull;</span>
     <span class="grid-hover-label">Value</span>
     <span class="grid-hover-value">{{
-      hoveredGridPoint.status === HOVERED_GRID_POINT_STATUS.MISSING
+      hoveredGridPoint.status === HOVERED_GRID_POINT_STATUS.MISSING ||
+      hoveredGridPoint.value === undefined ||
+      hoveredGridPoint.value === null
         ? "No data"
-        : hoveredGridPoint.value?.toFixed(5)
+        : formatValue(hoveredGridPoint.value)
     }}</span>
   </div>
   <div v-else />

--- a/src/ui/overlays/HoverReadout.vue
+++ b/src/ui/overlays/HoverReadout.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
+import { computed, ref, watch } from "vue";
 
 import {
   HOVERED_GRID_POINT_STATUS,
@@ -8,7 +9,81 @@ import {
 import { formatValue } from "@/utils/formatValue";
 
 const store = useGlobeControlStore();
-const { hoveredGridPoint } = storeToRefs(store);
+const { hoveredGridPoint, colormap, invertColormap, selection } =
+  storeToRefs(store);
+
+const OFFSET_Y = 12;
+const COLORMAP_WIDTH = 256;
+
+const tooltipStyle = computed(() => {
+  if (!hoveredGridPoint.value) {
+    return {};
+  }
+  return {
+    left: `${hoveredGridPoint.value.screenX}px`,
+    top: `${hoveredGridPoint.value.screenY - OFFSET_Y}px`,
+  };
+});
+
+// Offscreen canvas for sampling colormap colors
+const colormapCanvas = document.createElement("canvas");
+colormapCanvas.width = COLORMAP_WIDTH;
+colormapCanvas.height = 1;
+const colormapCtx = colormapCanvas.getContext("2d", {
+  willReadFrequently: true,
+})!;
+let loadedColormapName = "";
+
+function loadColormapImage(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      colormapCtx.drawImage(img, 0, 0, COLORMAP_WIDTH, 1);
+      loadedColormapName = name;
+      resolve();
+    };
+    img.onerror = () => resolve();
+    img.src = `/static/colormaps/${name}.webp`;
+  });
+}
+
+const swatchColor = ref<string | null>(null);
+
+watch(
+  [hoveredGridPoint, colormap, invertColormap, selection],
+  async ([point, cm]) => {
+    if (
+      !point ||
+      point.status === HOVERED_GRID_POINT_STATUS.MISSING ||
+      point.value === undefined ||
+      point.value === null
+    ) {
+      swatchColor.value = null;
+      return;
+    }
+
+    if (loadedColormapName !== cm) {
+      await loadColormapImage(cm);
+    }
+
+    const range = selection.value.high - selection.value.low;
+    if (range === 0) {
+      swatchColor.value = null;
+      return;
+    }
+
+    let t = (point.value - selection.value.low) / range;
+    t = Math.max(0, Math.min(1, t));
+    if (invertColormap.value) {
+      t = 1 - t;
+    }
+
+    const x = Math.round(t * (COLORMAP_WIDTH - 1));
+    const pixel = colormapCtx.getImageData(x, 0, 1, 1).data;
+    swatchColor.value = `rgb(${pixel[0]}, ${pixel[1]}, ${pixel[2]})`;
+  },
+  { immediate: true }
+);
 
 function formatCoordinate(value: number) {
   return `${value.toFixed(2)}°`;
@@ -16,7 +91,7 @@ function formatCoordinate(value: number) {
 </script>
 
 <template>
-  <div v-if="hoveredGridPoint" class="grid-hover-readout">
+  <div v-if="hoveredGridPoint" class="grid-hover-readout" :style="tooltipStyle">
     <span class="grid-hover-label">Lat</span>
     <span class="grid-hover-value">{{
       formatCoordinate(hoveredGridPoint.lat)
@@ -28,6 +103,11 @@ function formatCoordinate(value: number) {
     }}</span>
     <span class="grid-hover-separator">&bull;</span>
     <span class="grid-hover-label">Value</span>
+    <span
+      v-if="swatchColor"
+      class="grid-hover-swatch"
+      :style="{ background: swatchColor }"
+    />
     <span class="grid-hover-value">{{
       hoveredGridPoint.status === HOVERED_GRID_POINT_STATUS.MISSING ||
       hoveredGridPoint.value === undefined ||
@@ -35,16 +115,15 @@ function formatCoordinate(value: number) {
         ? "No data"
         : formatValue(hoveredGridPoint.value)
     }}</span>
+    <span class="grid-hover-arrow" />
   </div>
   <div v-else />
 </template>
 
 <style lang="scss" scoped>
 .grid-hover-readout {
-  position: absolute;
-  left: 50%;
-  bottom: 18px;
-  transform: translateX(-50%);
+  position: fixed;
+  transform: translate(-50%, -100%);
   z-index: 1050;
   pointer-events: none;
   display: inline-flex;
@@ -58,6 +137,26 @@ function formatCoordinate(value: number) {
   border-radius: 999px;
   font-size: 0.9rem;
   white-space: nowrap;
+}
+
+.grid-hover-arrow {
+  position: absolute;
+  left: 50%;
+  bottom: -6px;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid rgba(17, 24, 39, 0.92);
+}
+
+.grid-hover-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
 }
 
 .grid-hover-label {

--- a/src/ui/overlays/controls/ActionControls.vue
+++ b/src/ui/overlays/controls/ActionControls.vue
@@ -85,5 +85,3 @@ const showPresenter = !isMobileDevice();
     </div>
   </div>
 </template>
-
-<style lang="scss" scoped></style>

--- a/src/ui/overlays/controls/BoundsControls.vue
+++ b/src/ui/overlays/controls/BoundsControls.vue
@@ -8,11 +8,6 @@ import { useGlobeControlStore } from "@/store/store.ts";
 const props = defineProps<{
   pickedBoundsMode: string;
   dataBounds: TBounds;
-  defaultBounds: TBounds;
-  currentBounds:
-    | TBounds
-    | { low: number | undefined; high: number | undefined }
-    | undefined;
   boundModes: Record<string, string>;
 }>();
 

--- a/src/ui/overlays/controls/ColorBar.vue
+++ b/src/ui/overlays/controls/ColorBar.vue
@@ -11,11 +11,7 @@ import {
   nextTick,
 } from "vue";
 
-import {
-  formatValue,
-  computeBinTooltip,
-  type BinTooltip,
-} from "./colorbarUtils.ts";
+import { computeBinTooltip, type BinTooltip } from "./colorbarUtils.ts";
 
 import {
   availableColormaps,
@@ -25,6 +21,7 @@ import { makeCompressedColormapLutMaterial } from "@/lib/shaders/gridShaders.ts"
 import { useGlobeControlStore } from "@/store/store.ts";
 import RangeSlider from "@/ui/common/RangeSlider.vue";
 import DistributionPlot from "@/ui/overlays/controls/DistributionPlot.vue";
+import { formatValue } from "@/utils/formatValue.ts";
 
 const props = withDefaults(
   defineProps<{
@@ -254,7 +251,7 @@ const hoveredValueLabel = computed(() => {
   if (!point) {
     return null;
   }
-  return point.value === null ? "No data" : point.value.toFixed(5);
+  return point.value === null ? "No data" : formatValue(point.value);
 });
 
 const hoveredMarkerStyle = computed(() => {

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -4,7 +4,7 @@ import Select from "primevue/select";
 import { ref, watch } from "vue";
 
 import ColorBar from "./ColorBar.vue";
-import { roundToDataPrecision } from "./colorbarUtils.ts";
+import { percentileFromBins, roundToDataPrecision } from "./colorbarUtils.ts";
 
 import type { TColorMap } from "@/lib/shaders/colormapShaders.ts";
 import type { TBounds, TModelInfo } from "@/lib/types/GlobeTypes.ts";
@@ -29,6 +29,7 @@ const {
   selection,
   histogram,
   fullHistogram,
+  histogramSummary,
 } = storeToRefs(store);
 
 const previousValue = ref(posterizeLevels.value);
@@ -109,6 +110,22 @@ function handleDropdownChange() {
 function handleOptionHover(option: TColorMap) {
   colormap.value = option;
 }
+
+function handleAutoContrast() {
+  if (!histogramSummary.value || !props.dataBounds) {
+    return;
+  }
+  const { bins, min, max } = histogramSummary.value;
+  const low = percentileFromBins(bins, min, max, 2);
+  const high = percentileFromBins(bins, min, max, 98);
+  store.updateLowUserBound(
+    roundToDataPrecision(low, props.dataBounds.low, props.dataBounds.high)
+  );
+  store.updateHighUserBound(
+    roundToDataPrecision(high, props.dataBounds.low, props.dataBounds.high)
+  );
+  emit("forceUserBounds");
+}
 </script>
 
 <template>
@@ -154,41 +171,41 @@ function handleOptionHover(option: TColorMap) {
     </div>
 
     <!-- Row: Colormap selector + options -->
+    <div class="column colormap-column">
+      <Select
+        v-model="colormap"
+        :options="modelInfo.colormaps"
+        class="colormap-select"
+        @show="handleDropdownShow"
+        @hide="handleDropdownHide"
+        @change="handleDropdownChange"
+      >
+        <template #value="{ value }">
+          <div class="cm-option">
+            <img
+              :src="swatchSrc(value as TColorMap)"
+              class="cm-swatch"
+              alt=""
+            />
+            <span class="cm-name">{{ value }}</span>
+          </div>
+        </template>
+        <template #option="{ option }">
+          <div
+            class="cm-option"
+            @mouseenter="handleOptionHover(option as TColorMap)"
+          >
+            <img
+              :src="swatchSrc(option as TColorMap)"
+              class="cm-swatch"
+              alt=""
+            />
+            <span class="cm-name">{{ option }}</span>
+          </div>
+        </template>
+      </Select>
+    </div>
     <div class="columns is-mobile is-vcentered compact-row px-1">
-      <div class="column colormap-column">
-        <Select
-          v-model="colormap"
-          :options="modelInfo.colormaps"
-          class="colormap-select"
-          @show="handleDropdownShow"
-          @hide="handleDropdownHide"
-          @change="handleDropdownChange"
-        >
-          <template #value="{ value }">
-            <div class="cm-option">
-              <img
-                :src="swatchSrc(value as TColorMap)"
-                class="cm-swatch"
-                alt=""
-              />
-              <span class="cm-name">{{ value }}</span>
-            </div>
-          </template>
-          <template #option="{ option }">
-            <div
-              class="cm-option"
-              @mouseenter="handleOptionHover(option as TColorMap)"
-            >
-              <img
-                :src="swatchSrc(option as TColorMap)"
-                class="cm-swatch"
-                alt=""
-              />
-              <span class="cm-name">{{ option }}</span>
-            </div>
-          </template>
-        </Select>
-      </div>
       <div class="column is-narrow">
         <label class="checkbox">
           <input
@@ -211,6 +228,20 @@ function handleOptionHover(option: TColorMap) {
           />
           hide low
         </label>
+      </div>
+      <div class="column is-narrow">
+        <button
+          type="button"
+          class="button is-small"
+          title="Set bounds to the 2nd - 98th percentile of the data"
+          :disabled="!histogramSummary || !dataBounds"
+          @click="handleAutoContrast"
+        >
+          <span class="icon">
+            <i class="fa-solid fa-circle-half-stroke"></i>
+          </span>
+          <span> Auto Contrast </span>
+        </button>
       </div>
     </div>
   </div>

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -171,7 +171,7 @@ function handleAutoContrast() {
     </div>
 
     <!-- Row: Colormap selector + options -->
-    <div class="column colormap-column">
+    <div class="w-100 colormap-column mb-4">
       <Select
         v-model="colormap"
         :options="modelInfo.colormaps"
@@ -206,7 +206,7 @@ function handleAutoContrast() {
       </Select>
     </div>
     <div class="columns is-mobile is-vcentered compact-row px-1">
-      <div class="column is-narrow">
+      <div class="column">
         <label class="checkbox">
           <input
             id="invert_colormap"
@@ -216,7 +216,7 @@ function handleAutoContrast() {
           invert
         </label>
       </div>
-      <div class="column is-narrow">
+      <div class="column">
         <label
           class="checkbox"
           title="Hide values at or below the lower bound (useful with globe mask, e.g. for precipitation)"
@@ -229,7 +229,7 @@ function handleAutoContrast() {
           hide low
         </label>
       </div>
-      <div class="column is-narrow">
+      <div class="column">
         <button
           type="button"
           class="button is-small"

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -130,7 +130,9 @@ function handleOptionHover(option: TColorMap) {
     <!-- Posterize control -->
     <div class="columns is-mobile is-vcentered compact-row mt-2 mb-4 px-1">
       <div class="column is-one-third">
-        <label for="posterize_levels" class="label is-small">Posterize</label>
+        <label for="posterize_levels" class="label is-small"
+          >Discrete Colors</label
+        >
       </div>
       <div class="column slider-column">
         <input

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -129,7 +129,7 @@ function handleAutoContrast() {
 </script>
 
 <template>
-  <div class="column">
+  <div class="column mb-5">
     <ColorBar
       :colormap="colormap"
       :invert-colormap="invertColormap"
@@ -207,32 +207,41 @@ function handleAutoContrast() {
     </div>
     <div class="columns is-mobile is-vcentered compact-row px-1">
       <div class="column">
-        <label class="checkbox">
-          <input
-            id="invert_colormap"
-            v-model="invertColormap"
-            type="checkbox"
-          />
-          invert
-        </label>
+        <button
+          id="invert_colormap"
+          type="button"
+          class="button is-small w-100"
+          :class="{ 'is-info': invertColormap }"
+          :aria-pressed="invertColormap"
+          title="Invert colormap"
+          @click="invertColormap = !invertColormap"
+        >
+          <span class="icon">
+            <i class="fa-solid fa-arrow-right-arrow-left"></i>
+          </span>
+          <span>Invert</span>
+        </button>
       </div>
       <div class="column">
-        <label
-          class="checkbox"
+        <button
+          id="hide_lower_bound"
+          type="button"
+          class="button is-small w-100"
+          :class="{ 'is-info': hideLowerBound }"
+          :aria-pressed="hideLowerBound"
           title="Hide values at or below the lower bound (useful with globe mask, e.g. for precipitation)"
+          @click="hideLowerBound = !hideLowerBound"
         >
-          <input
-            id="hide_lower_bound"
-            v-model="hideLowerBound"
-            type="checkbox"
-          />
-          hide low
-        </label>
+          <span class="icon">
+            <i class="fa-solid fa-eye-slash"></i>
+          </span>
+          <span>Hide low</span>
+        </button>
       </div>
       <div class="column">
         <button
           type="button"
-          class="button is-small"
+          class="button is-small w-100"
           title="Set bounds to the 2nd - 98th percentile of the data"
           :disabled="!histogramSummary || !dataBounds"
           @click="handleAutoContrast"

--- a/src/ui/overlays/controls/DatetimePicker.vue
+++ b/src/ui/overlays/controls/DatetimePicker.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
+import { VueDatePicker } from "@vuepic/vue-datepicker";
 import dayjs, { Dayjs } from "dayjs";
 import utc from "dayjs/plugin/utc.js";
-import DatePicker from "primevue/datepicker";
+import "@vuepic/vue-datepicker/dist/main.css";
 import { computed, ref, watch } from "vue";
 
 import { findTimeIndex, decodeTime } from "@/lib/data/timeHandling.ts";
@@ -144,11 +145,11 @@ function openPicker() {
   >
     <!-- Range info -->
     <div v-if="minDatetime && maxDatetime" class="mb-2">
-      <p class="has-text-grey">Available range</p>
+      <p class="label mb-1">Available range</p>
       <p>
-        <strong>{{ minDatetime.format("YYYY-MM-DD HH:mm:ss") }}</strong>
+        {{ minDatetime.format("YYYY-MM-DD HH:mm:ss") }}
         to
-        <strong>{{ maxDatetime.format("YYYY-MM-DD HH:mm:ss") }}</strong>
+        {{ maxDatetime.format("YYYY-MM-DD HH:mm:ss") }}
       </p>
     </div>
 
@@ -156,27 +157,39 @@ function openPicker() {
     <div class="field mb-2">
       <label class="label mb-1">Enter datetime</label>
       <div class="control">
-        <DatePicker
+        <VueDatePicker
           v-model="inputDatetime"
-          show-time
-          show-seconds
+          :formats="{ input: 'yyyy-MM-dd HH:mm:ss' }"
           :min-date="minDatetime?.toDate()"
           :max-date="maxDatetime?.toDate()"
-          date-format="yy-m-d"
-          hour-format="24"
-          show-icon
-          :show-on-focus="false"
-          fluid
-          :invalid="!inputDatetime"
+          teleport
+          text-input
           @update:model-value="onInputChange"
-          @blur="onInputChange"
+          @text-input="onInputChange"
         >
-          <template #footer>
-            <span v-if="previewIndex !== null" class="tag is-info is-light">
-              New Index: {{ previewIndex }}
+          <template #action-row="{ selectDate, closePicker, modelValue }">
+            <span class="ml-2 mr-4" :class="[!modelValue && 'has-text-danger']">
+              {{
+                modelValue
+                  ? dayjs(modelValue as Date).format("YYYY-MM-DD HH:mm")
+                  : "Invalid date"
+              }}
             </span>
+            <div class="buttons ml-auto">
+              <button class="button" type="button" @click="closePicker">
+                Cancel
+              </button>
+              <button
+                class="button is-success"
+                type="button"
+                :disabled="!modelValue"
+                @click="selectDate"
+              >
+                Select
+              </button>
+            </div>
           </template>
-        </DatePicker>
+        </VueDatePicker>
       </div>
       <p class="help">Format: YYYY-MM-DD HH:mm:ss</p>
     </div>
@@ -185,7 +198,6 @@ function openPicker() {
     <div
       class="is-flex is-justify-content-space-between is-align-items-center mb-2"
     >
-      <span class="has-text-grey">Selection Preview</span>
       <span v-if="errorMessage" class="is-size-7 has-text-danger">
         <i class="fas fa-exclamation-circle"></i>
         {{ errorMessage }}
@@ -193,22 +205,19 @@ function openPicker() {
     </div>
     <div class="preview-content">
       <template v-if="previewIndex !== null && previewDatetime">
-        <p class="mb-1">
-          <span class="has-text-grey">New Index:</span>
-          <strong class="ml-2">{{ previewIndex }}</strong>
-          <span class="has-text-grey-light ml-2"
-            >(of {{ minIndex }}–{{ maxIndex }})</span
-          >
-        </p>
-        <p class="mb-1">
-          <span class="has-text-grey">Datetime:</span>
-          <strong class="ml-2"
-            >{{ previewDatetime.format("YYYY-MM-DD HH:mm:ss") }}
-          </strong>
-        </p>
-        <p class="has-text-grey mt-2 pt-2 current-hint">
-          Old Index: {{ currentIndex }}
-        </p>
+        <dl>
+          <dt class="label">
+            New Index
+            <span class="has-text-grey-light"
+              >(of {{ minIndex }}–{{ maxIndex }})</span
+            >
+          </dt>
+          <dd>{{ previewIndex }}</dd>
+          <dt class="label">Datetime at new index</dt>
+          <dd>{{ previewDatetime.format("YYYY-MM-DD HH:mm:ss") }}</dd>
+          <dt class="label has-text-grey-light">Current Index</dt>
+          <dd>{{ currentIndex }}</dd>
+        </dl>
       </template>
       <template v-else>
         <p class="has-text-grey-light has-text-centered py-4">
@@ -241,14 +250,41 @@ function openPicker() {
   min-height: 65px;
 }
 
-.current-hint {
-  border-top: 1px dashed #dbdbdb;
+.preview-content dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25em 0.5em;
 }
-</style>
 
-<style>
-.p-datepicker-input:focus {
+:root {
+  --dp-border-radius: var(--bulma-control-radius);
+  --dp-cell-border-radius: var(--bulma-control-radius);
+  --dp-cell-size: 45px; /*Width and height of calendar cell*/
+}
+
+.dp--theme-light {
+  --dp-primary-color: var(--bulma-success);
+  --dp-primary-disabled-color: var(--bulma-button-disabled-background-color);
+  --dp-primary-text-color: var(--bulma-text);
+}
+
+.dp--input {
+  box-shadow: var(
+    --bulma-input-shadow,
+    inset 0 0.0625em 0.125em rgba(10, 10, 10, 0.05)
+  );
+  height: var(--bulma-control-height, 2.5em);
+}
+
+.dp--input-focus {
   border-color: #485fc7 !important;
-  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25) !important;
+  box-shadow: 0 0 0 0.125em
+    color-mix(in srgb, var(--bulma-link) 25%, transparent);
+}
+
+.dp--overlay-cell-disabled {
+  background-color: var(--bulma-background);
+  color: var(--bulma-text);
+  opacity: 0.5;
 }
 </style>

--- a/src/ui/overlays/controls/DatetimePicker.vue
+++ b/src/ui/overlays/controls/DatetimePicker.vue
@@ -163,6 +163,11 @@ function openPicker() {
           :min-date="minDatetime?.toDate()"
           :max-date="maxDatetime?.toDate()"
           teleport
+          :year-range="
+            minDatetime && maxDatetime
+              ? [minDatetime.year(), maxDatetime.year()]
+              : [0, 9999]
+          "
           text-input
           @update:model-value="onInputChange"
           @text-input="onInputChange"

--- a/src/ui/overlays/controls/DatetimePicker.vue
+++ b/src/ui/overlays/controls/DatetimePicker.vue
@@ -245,7 +245,7 @@ function openPicker() {
   </Modal>
 </template>
 
-<style scoped>
+<style>
 .preview-content {
   min-height: 65px;
 }

--- a/src/ui/overlays/controls/DimensionControl.vue
+++ b/src/ui/overlays/controls/DimensionControl.vue
@@ -4,12 +4,16 @@ import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import DatetimePicker from "./DatetimePicker.vue";
+import { useTimeAnimation } from "./useTimeAnimation.ts";
 
 import { decodeTime, isTimeUnits } from "@/lib/data/timeHandling.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
 
 const store = useGlobeControlStore();
 const { varinfo, dimSlidersValues } = storeToRefs(store);
+
+const { isPlaying, canAnimate, toggle, cycleSpeed, speedLabel } =
+  useTimeAnimation();
 
 // Local copies for debounced updates (excluding time dimension)
 const localSliders = ref<(number | null)[]>([]);
@@ -158,6 +162,34 @@ function capitalize(str: string): string {
           :min="range.minBound"
           :max="range.maxBound"
         />
+
+        <div
+          v-if="isTimeDimension(index) && canAnimate"
+          class="is-flex is-align-items-center mt-2"
+          style="gap: 0.5rem"
+        >
+          <button
+            class="button is-small"
+            :class="{ 'is-info': isPlaying }"
+            type="button"
+            :title="
+              isPlaying ? 'Pause animation (Space)' : 'Play animation (Space)'
+            "
+            @click="toggle"
+          >
+            <span class="icon">
+              <i :class="isPlaying ? 'fas fa-pause' : 'fas fa-play'"></i>
+            </span>
+          </button>
+          <button
+            class="button is-small"
+            type="button"
+            title="Playback speed"
+            @click="cycleSpeed"
+          >
+            {{ speedLabel }}
+          </button>
+        </div>
 
         <div class="w-100 is-flex is-justify-content-space-between">
           <div>Current value</div>

--- a/src/ui/overlays/controls/DimensionControl.vue
+++ b/src/ui/overlays/controls/DimensionControl.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import { useDebounceFn } from "@vueuse/core";
-import type { Dayjs } from "dayjs";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import DatetimePicker from "./DatetimePicker.vue";
 
+import { decodeTime, isTimeUnits } from "@/lib/data/timeHandling.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
 
 const store = useGlobeControlStore();
@@ -15,18 +15,23 @@ const { varinfo, dimSlidersValues } = storeToRefs(store);
 const localSliders = ref<(number | null)[]>([]);
 const debouncedUpdaters = ref<Array<(value: number) => void>>([]);
 
-const timeRangeIndex = computed(() => {
-  return (
-    varinfo.value?.dimRanges.findIndex((range) => range?.name === "time") ?? -1
-  );
-});
+function getTimeUnits(index: number): string | undefined {
+  const dimInfo = varinfo.value?.dimInfo[index];
+  return dimInfo && "attrs" in dimInfo && isTimeUnits(dimInfo.attrs.units)
+    ? dimInfo.attrs.units
+    : undefined;
+}
+
+function isTimeDimension(index: number): boolean {
+  return getTimeUnits(index) !== undefined;
+}
 
 const hasValidDimensions = computed(() => {
   return (
     varinfo.value &&
     varinfo.value.dimRanges.length > 1 &&
     varinfo.value.dimRanges.some(
-      (range) => range && (range.maxBound > 0 || range.name === "time")
+      (range, index) => range && (range.maxBound > 0 || isTimeDimension(index))
     )
   );
 });
@@ -74,11 +79,26 @@ watch(
 );
 
 // Handler for datetime picker
-function onDatetimeIndexUpdate(index: number) {
-  if (timeRangeIndex.value !== -1) {
-    localSliders.value[timeRangeIndex.value] = index;
-    dimSlidersValues.value[timeRangeIndex.value] = index;
+function onDatetimeIndexUpdate(dimensionIndex: number, index: number) {
+  localSliders.value[dimensionIndex] = index;
+  dimSlidersValues.value[dimensionIndex] = index;
+}
+
+function formatCurrentValue(index: number) {
+  const dimInfo = varinfo.value?.dimInfo[index];
+  if (!dimInfo || !("current" in dimInfo)) {
+    return "-";
   }
+  if (!isTimeDimension(index)) {
+    return dimInfo.current;
+  }
+  if (typeof dimInfo.current === "object") {
+    return dimInfo.current.format();
+  }
+  const current = Number(dimInfo.current);
+  return Number.isFinite(current)
+    ? decodeTime(current, dimInfo.attrs).format()
+    : "-";
 }
 
 function capitalize(str: string): string {
@@ -97,7 +117,7 @@ function capitalize(str: string): string {
   >
     <template v-for="(range, index) in varinfo!.dimRanges" :key="index">
       <div
-        v-if="range && (range.maxBound > 0 || range.name === 'time')"
+        v-if="range && (range.maxBound > 0 || isTimeDimension(index))"
         class="control"
         :class="{ 'mb-4': index + 1 < varinfo.dimInfo.length }"
       >
@@ -109,13 +129,13 @@ function capitalize(str: string): string {
           <div class="is-flex is-align-items-center" style="gap: 0.5rem">
             {{ capitalize(range.name) }}:
             <DatetimePicker
-              v-if="range.name === 'time'"
+              v-if="isTimeDimension(index)"
               :time-values="varinfo.dimInfo[index]?.values ?? []"
               :time-attrs="varinfo.dimInfo[index]?.attrs ?? {}"
               :current-index="localSliders[index] ?? 0"
               :min-index="range?.minBound ?? 0"
               :max-index="range?.maxBound ?? 0"
-              @update:index="onDatetimeIndexUpdate"
+              @update:index="onDatetimeIndexUpdate(index, $event)"
             />
           </div>
           <div class="is-flex">
@@ -142,12 +162,7 @@ function capitalize(str: string): string {
         <div class="w-100 is-flex is-justify-content-space-between">
           <div>Current value</div>
           <div class="has-text-right">
-            <span v-if="varinfo.dimRanges[index]?.name === 'time'">
-              {{
-                (varinfo.dimInfo[index]?.current as Dayjs)?.format?.() ?? "-"
-              }}
-            </span>
-            <span v-else>{{ varinfo.dimInfo[index]?.current ?? "-" }}</span>
+            <span>{{ formatCurrentValue(index) }}</span>
             <br />
           </div>
         </div>

--- a/src/ui/overlays/controls/DistributionPlot.vue
+++ b/src/ui/overlays/controls/DistributionPlot.vue
@@ -17,11 +17,9 @@ import {
   nextTick,
 } from "vue";
 
-import {
-  computeBinTooltip,
-  formatValue,
-  type BinTooltip,
-} from "./colorbarUtils.ts";
+import { computeBinTooltip, type BinTooltip } from "./colorbarUtils.ts";
+
+import { formatValue } from "@/utils/formatValue.ts";
 
 // ---------------------------------------------------------------------------
 // Props & emits

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -4,77 +4,169 @@ import { storeToRefs } from "pinia";
 import { useGlobeControlStore } from "@/store/store.ts";
 
 const store = useGlobeControlStore();
-const { landSeaMaskChoice, landSeaMaskUseTexture } = storeToRefs(store);
+const {
+  landSeaMaskChoice,
+  landSeaMaskUseTexture,
+  showCoastLines,
+  showGraticules,
+} = storeToRefs(store);
+
+function toggleTexture() {
+  if (landSeaMaskChoice.value === "off") {
+    return;
+  }
+  landSeaMaskUseTexture.value = !landSeaMaskUseTexture.value;
+}
 </script>
 
 <template>
-  <div class="panel-block">
-    <div class="">
-      <div class="columns compact-row is-flex is-align-items-center">
-        <div class="column">
-          <div class="control has-icons-left">
-            <div class="select">
-              <select id="land_sea_mask" v-model="landSeaMaskChoice">
-                <option value="off">-- Mask: Off --</option>
-                <option value="land">Land</option>
-                <option value="sea">Sea</option>
-                <option value="globe">Globe</option>
-              </select>
-            </div>
-            <span class="icon is-medium is-left">
-              <i
-                class="fas"
-                :class="
-                  landSeaMaskChoice === 'globe'
-                    ? 'fa-globe'
-                    : landSeaMaskChoice === 'land'
-                      ? 'fa-mountain'
-                      : landSeaMaskChoice === 'sea'
-                        ? 'fa-water'
-                        : 'fa-mask'
-                "
-              ></i>
-            </span>
-          </div>
+  <div class="column">
+    <div class="grid">
+      <div class="cell control has-icons-left">
+        <div class="select">
+          <select id="land_sea_mask" v-model="landSeaMaskChoice">
+            <option value="off">Mask: Off</option>
+            <option value="land">Land</option>
+            <option value="sea">Sea</option>
+            <option value="globe">Globe</option>
+          </select>
         </div>
-        <div class="column has-text-right">
-          <input
-            id="use_texture"
-            v-model="landSeaMaskUseTexture"
-            :disabled="landSeaMaskChoice === 'off'"
-            type="checkbox"
-          />
-          <label
-            for="use_texture"
-            title="Earth texture credit: NASA"
-            :class="{
-              'has-text-grey-light': landSeaMaskChoice === 'off',
-            }"
-            >Use texture</label
-          >
-        </div>
+        <span class="icon is-medium is-left">
+          <i
+            class="fas"
+            :class="
+              landSeaMaskChoice === 'globe'
+                ? 'fa-globe'
+                : landSeaMaskChoice === 'land'
+                  ? 'fa-mountain'
+                  : landSeaMaskChoice === 'sea'
+                    ? 'fa-water'
+                    : 'fa-mask'
+            "
+          ></i>
+        </span>
       </div>
-
-      <div class="columns compact-row py-2">
-        <div class="column">
-          <input
-            id="enable_coastlines"
-            type="checkbox"
-            :checked="store.showCoastLines"
-            @change="store.toggleCoastLines"
-          />
-          <label for="enable_coastlines">Coastlines</label>
-        </div>
-        <div class="column">
-          <input
-            id="enable_graticules"
-            type="checkbox"
-            :checked="store.showGraticules"
-            @change="store.toggleGraticules"
-          />
-          <label for="enable_graticules">Lat/Lon Grid</label>
-        </div>
-      </div>
+      <button
+        class="button cell"
+        :class="{ 'is-info': landSeaMaskUseTexture }"
+        :disabled="landSeaMaskChoice === 'off'"
+        :title="
+          landSeaMaskChoice === 'off'
+            ? 'Select a mask type to enable texture option'
+            : 'Earth texture credit: NASA'
+        "
+        type="button"
+        :aria-pressed="landSeaMaskUseTexture"
+        @click="toggleTexture"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-image"></i>
+        </span>
+        <span>Use texture</span>
+      </button>
+      <button
+        class="button cell"
+        :class="{ 'is-info': showCoastLines }"
+        type="button"
+        title="Toggle coastlines"
+        @click="store.toggleCoastLines"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-earth-europe"></i>
+        </span>
+        <span>Coastlines</span>
+      </button>
+      <button
+        class="button cell"
+        :class="{ 'is-info': showGraticules }"
+        type="button"
+        title="Toggle lat/lon grid"
+        @click="store.toggleGraticules"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-globe"></i>
+        </span>
+        <span>Lat/Lon Grid</span>
+      </button>
     </div>
   </div>
 </template>
+
+<!--
+<template>
+  <div class="column">
+    <div class="w-100 is-flex gap is-justify-content-space-between pb-2">
+      <div class="control has-icons-left w-100">
+        <div class="select w-100">
+          <select id="land_sea_mask" v-model="landSeaMaskChoice">
+            <option value="off">Mask: Off</option>
+            <option value="land">Land</option>
+            <option value="sea">Sea</option>
+            <option value="globe">Globe</option>
+          </select>
+        </div>
+        <span class="icon is-medium is-left">
+          <i
+            class="fas"
+            :class="
+              landSeaMaskChoice === 'globe'
+                ? 'fa-globe'
+                : landSeaMaskChoice === 'land'
+                  ? 'fa-mountain'
+                  : landSeaMaskChoice === 'sea'
+                    ? 'fa-water'
+                    : 'fa-mask'
+            "
+          ></i>
+        </span>
+      </div>
+      <button
+        class="button w-100"
+        :class="{ 'is-info': landSeaMaskUseTexture }"
+        :disabled="landSeaMaskChoice === 'off'"
+        title="Earth texture credit: NASA"
+        type="button"
+        :aria-pressed="landSeaMaskUseTexture"
+        @click="toggleTexture"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-image"></i>
+        </span>
+        <span>Use texture</span>
+      </button>
+    </div>
+
+    <div class="w-100 is-flex gap is-justify-content-space-between py-2">
+      <button
+        class="button w-100"
+        :class="{ 'is-info': showCoastLines }"
+        type="button"
+        title="Toggle coastlines"
+        @click="store.toggleCoastLines"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-earth-europe"></i>
+        </span>
+        <span>Coastlines</span>
+      </button>
+      <button
+        class="button w-100"
+        :class="{ 'is-info': showGraticules }"
+        type="button"
+        title="Toggle lat/lon grid"
+        @click="store.toggleGraticules"
+      >
+        <span class="icon">
+          <i class="fa-solid fa-globe"></i>
+        </span>
+        <span>Lat/Lon Grid</span>
+      </button>
+    </div>
+  </div>
+</template> -->
+
+<style lang="scss" scoped>
+.gap {
+  gap: 0.5em;
+}
+</style>

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -91,9 +91,3 @@ function toggleTexture() {
     </div>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.gap {
-  gap: 0.5em;
-}
-</style>

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -24,7 +24,7 @@ function toggleTexture() {
     <div class="grid">
       <div class="cell control has-icons-left">
         <div class="select">
-          <select id="land_sea_mask" v-model="landSeaMaskChoice">
+          <select id="land_sea_mask" v-model="landSeaMaskChoice" class="w-100">
             <option value="off">Mask: Off</option>
             <option value="land">Land</option>
             <option value="sea">Sea</option>
@@ -91,79 +91,6 @@ function toggleTexture() {
     </div>
   </div>
 </template>
-
-<!--
-<template>
-  <div class="column">
-    <div class="w-100 is-flex gap is-justify-content-space-between pb-2">
-      <div class="control has-icons-left w-100">
-        <div class="select w-100">
-          <select id="land_sea_mask" v-model="landSeaMaskChoice">
-            <option value="off">Mask: Off</option>
-            <option value="land">Land</option>
-            <option value="sea">Sea</option>
-            <option value="globe">Globe</option>
-          </select>
-        </div>
-        <span class="icon is-medium is-left">
-          <i
-            class="fas"
-            :class="
-              landSeaMaskChoice === 'globe'
-                ? 'fa-globe'
-                : landSeaMaskChoice === 'land'
-                  ? 'fa-mountain'
-                  : landSeaMaskChoice === 'sea'
-                    ? 'fa-water'
-                    : 'fa-mask'
-            "
-          ></i>
-        </span>
-      </div>
-      <button
-        class="button w-100"
-        :class="{ 'is-info': landSeaMaskUseTexture }"
-        :disabled="landSeaMaskChoice === 'off'"
-        title="Earth texture credit: NASA"
-        type="button"
-        :aria-pressed="landSeaMaskUseTexture"
-        @click="toggleTexture"
-      >
-        <span class="icon">
-          <i class="fa-solid fa-image"></i>
-        </span>
-        <span>Use texture</span>
-      </button>
-    </div>
-
-    <div class="w-100 is-flex gap is-justify-content-space-between py-2">
-      <button
-        class="button w-100"
-        :class="{ 'is-info': showCoastLines }"
-        type="button"
-        title="Toggle coastlines"
-        @click="store.toggleCoastLines"
-      >
-        <span class="icon">
-          <i class="fa-solid fa-earth-europe"></i>
-        </span>
-        <span>Coastlines</span>
-      </button>
-      <button
-        class="button w-100"
-        :class="{ 'is-info': showGraticules }"
-        type="button"
-        title="Toggle lat/lon grid"
-        @click="store.toggleGraticules"
-      >
-        <span class="icon">
-          <i class="fa-solid fa-globe"></i>
-        </span>
-        <span>Lat/Lon Grid</span>
-      </button>
-    </div>
-  </div>
-</template> -->
 
 <style lang="scss" scoped>
 .gap {

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -15,7 +15,7 @@ const { landSeaMaskChoice, landSeaMaskUseTexture } = storeToRefs(store);
           <div class="control has-icons-left">
             <div class="select">
               <select id="land_sea_mask" v-model="landSeaMaskChoice">
-                <option value="off">-- Land/Sea Mask --</option>
+                <option value="off">-- Mask: Off --</option>
                 <option value="land">Land</option>
                 <option value="sea">Sea</option>
                 <option value="globe">Globe</option>

--- a/src/ui/overlays/controls/MaskControls.vue
+++ b/src/ui/overlays/controls/MaskControls.vue
@@ -23,7 +23,7 @@ function toggleTexture() {
   <div class="column">
     <div class="grid">
       <div class="cell control has-icons-left">
-        <div class="select">
+        <div class="select w-100">
           <select id="land_sea_mask" v-model="landSeaMaskChoice" class="w-100">
             <option value="off">Mask: Off</option>
             <option value="land">Land</option>

--- a/src/ui/overlays/controls/VariableSelector.vue
+++ b/src/ui/overlays/controls/VariableSelector.vue
@@ -49,7 +49,11 @@ function getOptionLabel(varname: string): string {
   <div class="column">
     <div class="control">
       <div class="select is-fullwidth mb-2" :class="{ 'is-loading': loading }">
-        <select v-model="model" class="form-control">
+        <select
+          v-model="model"
+          class="form-control"
+          @change="store.signifyVariableChange()"
+        >
           <option
             v-for="varname in variableOptions"
             :key="varname"

--- a/src/ui/overlays/controls/colorbarUtils.ts
+++ b/src/ui/overlays/controls/colorbarUtils.ts
@@ -1,5 +1,7 @@
 // Shared formatting and tooltip utilities for ColorBar and DistributionPlot.
 
+import { formatValue } from "@/utils/formatValue";
+
 /**
  * Returns the step size for a data range: two orders of magnitude below the
  * range itself. Used by BoundsControls (input step) and ColormapControls
@@ -35,17 +37,6 @@ export function roundToDataPrecision(
   }
   const decimals = Math.max(0, 2 - Math.floor(Math.log10(range)));
   return parseFloat(value.toFixed(decimals));
-}
-
-export function formatValue(value: number): string {
-  const abs = Math.abs(value);
-  if (abs === 0) {
-    return "0";
-  }
-  if (abs >= 1e6 || abs < 1e-4) {
-    return value.toExponential(1);
-  }
-  return String(parseFloat(value.toPrecision(3)));
 }
 
 export interface BinTooltip {

--- a/src/ui/overlays/controls/colorbarUtils.ts
+++ b/src/ui/overlays/controls/colorbarUtils.ts
@@ -83,3 +83,34 @@ export function computeBinTooltip(
     beyond,
   };
 }
+
+/**
+ * Compute the value at a given percentile from a histogram array.
+ * `bins` covers the range [min, max] uniformly.
+ */
+export function percentileFromBins(
+  bins: ArrayLike<number>,
+  min: number,
+  max: number,
+  percentile: number
+): number {
+  let total = 0;
+  for (let i = 0; i < bins.length; i++) {
+    total += bins[i];
+  }
+  if (total === 0) {
+    return min;
+  }
+  const target = total * (percentile / 100);
+  const binSize = (max - min) / bins.length;
+  let cumulative = 0;
+  for (let i = 0; i < bins.length; i++) {
+    cumulative += bins[i];
+    if (cumulative >= target) {
+      const overshoot = cumulative - target;
+      const fraction = 1 - overshoot / bins[i];
+      return min + (i + fraction) * binSize;
+    }
+  }
+  return max;
+}

--- a/src/ui/overlays/controls/useTimeAnimation.ts
+++ b/src/ui/overlays/controls/useTimeAnimation.ts
@@ -1,0 +1,213 @@
+import { storeToRefs } from "pinia";
+import {
+  computed,
+  onUnmounted,
+  ref,
+  watch,
+  type ComputedRef,
+  type Ref,
+} from "vue";
+
+import { isTimeUnits } from "@/lib/data/timeHandling.ts";
+import type { TDimensionRange, TVarInfo } from "@/lib/types/GlobeTypes.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
+
+export const PLAYBACK_SPEED = {
+  SLOW: 0,
+  NORMAL: 1,
+  FAST: 2,
+  MAX: 3,
+} as const;
+
+export type TPlaybackSpeed =
+  (typeof PLAYBACK_SPEED)[keyof typeof PLAYBACK_SPEED];
+
+type TPlayableDimensionRange = Exclude<TDimensionRange, null>;
+
+const PLAYBACK_SPEED_ORDER: readonly TPlaybackSpeed[] = [
+  PLAYBACK_SPEED.SLOW,
+  PLAYBACK_SPEED.NORMAL,
+  PLAYBACK_SPEED.FAST,
+  PLAYBACK_SPEED.MAX,
+];
+
+const SPEED_DELAYS: Record<TPlaybackSpeed, number> = {
+  [PLAYBACK_SPEED.SLOW]: 1500,
+  [PLAYBACK_SPEED.NORMAL]: 700,
+  [PLAYBACK_SPEED.FAST]: 200,
+  [PLAYBACK_SPEED.MAX]: 0,
+};
+
+const SPEED_LABELS: Record<TPlaybackSpeed, string> = {
+  [PLAYBACK_SPEED.SLOW]: "0.5x",
+  [PLAYBACK_SPEED.NORMAL]: "1x",
+  [PLAYBACK_SPEED.FAST]: "2x",
+  [PLAYBACK_SPEED.MAX]: "Max",
+};
+
+const isPlaying = ref(false);
+const speed = ref<TPlaybackSpeed>(PLAYBACK_SPEED.NORMAL);
+let activeToggle: (() => void) | null = null;
+
+export function toggleTimeAnimation() {
+  activeToggle?.();
+}
+
+type TAnimationContext = {
+  timeRangeIndex: ComputedRef<number>;
+  timeRange: ComputedRef<TPlayableDimensionRange | null>;
+  dimSlidersValues: Ref<(number | null)[]>;
+  loading: Ref<boolean>;
+  canAnimate: ComputedRef<boolean>;
+};
+
+type TAnimationStoreRefs = {
+  varinfo: Ref<TVarInfo | undefined>;
+  dimSlidersValues: Ref<(number | null)[]>;
+  loading: Ref<boolean>;
+};
+
+function createTimeRangeIndex(varinfo: Ref<TVarInfo | undefined>) {
+  return computed(() => {
+    const info = varinfo.value;
+    if (!info) {
+      return -1;
+    }
+    return info.dimRanges.findIndex((range, index) => {
+      if (range === null) {
+        return false;
+      }
+      const dimInfo = info.dimInfo[index];
+      return (
+        dimInfo !== undefined &&
+        "attrs" in dimInfo &&
+        isTimeUnits(dimInfo.attrs.units)
+      );
+    });
+  });
+}
+
+function createTimeAnimationContext(
+  refs: TAnimationStoreRefs
+): TAnimationContext {
+  const timeRangeIndex = createTimeRangeIndex(refs.varinfo);
+  const timeRange = computed<TPlayableDimensionRange | null>(() => {
+    const index = timeRangeIndex.value;
+    return index === -1 ? null : (refs.varinfo.value?.dimRanges[index] ?? null);
+  });
+  const canAnimate = computed(() => {
+    const range = timeRange.value;
+    return range !== null && range.maxBound > range.minBound;
+  });
+
+  return {
+    timeRangeIndex,
+    timeRange,
+    dimSlidersValues: refs.dimSlidersValues,
+    loading: refs.loading,
+    canAnimate,
+  };
+}
+
+function createAdvanceStep(ctx: TAnimationContext, stop: () => void) {
+  return function advanceStep() {
+    const index = ctx.timeRangeIndex.value;
+    const range = ctx.timeRange.value;
+    if (index === -1 || range === null) {
+      stop();
+      return;
+    }
+
+    const current = ctx.dimSlidersValues.value[index] ?? range.minBound;
+    const next = current + 1;
+    ctx.dimSlidersValues.value[index] =
+      next > range.maxBound ? range.minBound : next;
+  };
+}
+
+function createPlaybackControls(ctx: TAnimationContext) {
+  let delayTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function stop() {
+    isPlaying.value = false;
+    if (delayTimer !== null) {
+      clearTimeout(delayTimer);
+      delayTimer = null;
+    }
+  }
+
+  const advanceStep = createAdvanceStep(ctx, stop);
+
+  function scheduleNextStep() {
+    if (!isPlaying.value) {
+      return;
+    }
+    delayTimer = setTimeout(() => {
+      delayTimer = null;
+      advanceStep();
+    }, SPEED_DELAYS[speed.value]);
+  }
+
+  function play() {
+    if (!ctx.canAnimate.value) {
+      return;
+    }
+    isPlaying.value = true;
+    if (!ctx.loading.value) {
+      advanceStep();
+    }
+  }
+
+  function toggle() {
+    if (isPlaying.value) {
+      stop();
+    } else {
+      play();
+    }
+  }
+
+  function cycleSpeed() {
+    const currentIndex = PLAYBACK_SPEED_ORDER.indexOf(speed.value);
+    speed.value =
+      PLAYBACK_SPEED_ORDER[(currentIndex + 1) % PLAYBACK_SPEED_ORDER.length];
+  }
+
+  return { stop, toggle, cycleSpeed, scheduleNextStep };
+}
+
+export function useTimeAnimation() {
+  const store = useGlobeControlStore();
+  const { varinfo, dimSlidersValues, loading } = storeToRefs(store);
+  const animationContext = createTimeAnimationContext({
+    varinfo,
+    dimSlidersValues,
+    loading,
+  });
+
+  const { stop, toggle, cycleSpeed, scheduleNextStep } =
+    createPlaybackControls(animationContext);
+
+  activeToggle = toggle;
+
+  watch(loading, (isLoading, wasLoading) => {
+    if (isPlaying.value && wasLoading && !isLoading) {
+      scheduleNextStep();
+    }
+  });
+
+  onUnmounted(() => {
+    stop();
+    if (activeToggle === toggle) {
+      activeToggle = null;
+    }
+  });
+
+  return {
+    isPlaying,
+    speed,
+    canAnimate: animationContext.canAnimate,
+    toggle,
+    cycleSpeed,
+    speedLabel: computed(() => SPEED_LABELS[speed.value]),
+  };
+}

--- a/src/ui/overlays/infoPanel/DataStorageSection.vue
+++ b/src/ui/overlays/infoPanel/DataStorageSection.vue
@@ -3,6 +3,8 @@ import { computed } from "vue";
 
 import type { TInfoDimension } from "./types.ts";
 
+import { ZARR_FORMAT } from "@/lib/types/GlobeTypes.ts";
+
 const props = defineProps<{
   dimensions: TInfoDimension[];
   variableDtype: string | null;
@@ -59,7 +61,13 @@ const estimatedSizeMB = computed(() => {
           <tbody>
             <tr v-if="zarrFormat">
               <td><strong>Zarr format version</strong></td>
-              <td>{{ zarrFormat }}</td>
+              <td>
+                {{
+                  zarrFormat === ZARR_FORMAT.ICECHUNK
+                    ? "3 (icechunk)"
+                    : zarrFormat
+                }}
+              </td>
             </tr>
 
             <tr>

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -1,0 +1,12 @@
+// Utility function to format numerical values for display in the UI.
+// Used for example in the hover readout and colorbar tooltips.
+export function formatValue(value: number): string {
+  const abs = Math.abs(value);
+  if (abs === 0) {
+    return "0";
+  }
+  if (abs >= 1e6 || abs < 1e-4) {
+    return value.toExponential(1);
+  }
+  return String(parseFloat(value.toPrecision(3)));
+}

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -45,6 +45,7 @@ import GridIrregularDelaunay from "@/ui/grids/IrregularDelaunay.vue";
 import GridRegular from "@/ui/grids/Regular.vue";
 import GridTriangular from "@/ui/grids/Triangular.vue";
 import AboutView from "@/ui/overlays/AboutModal.vue";
+import { toggleTimeAnimation } from "@/ui/overlays/controls/useTimeAnimation.ts";
 import GlobeControls from "@/ui/overlays/Controls.vue";
 import HoverReadout from "@/ui/overlays/HoverReadout.vue";
 import InfoPanel from "@/ui/overlays/InfoPanel.vue";
@@ -390,6 +391,9 @@ useEventListener(window, "keydown", (e: KeyboardEvent) => {
     return;
   }
   const key = e.key.toLowerCase();
+  if (key === " " && tag === "button") {
+    return;
+  }
   if (key === "r") {
     toggleRotate();
   } else if (key === "d") {
@@ -398,6 +402,9 @@ useEventListener(window, "keydown", (e: KeyboardEvent) => {
     applyHyperglobePreset();
   } else if (key === "h" && !isMobileDevice()) {
     applyHyperglobePresenter();
+  } else if (key === " ") {
+    e.preventDefault();
+    toggleTimeAnimation();
   }
 });
 </script>

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -14,11 +14,7 @@ import {
   GRID_TYPES,
   type T_GRID_TYPES,
 } from "@/lib/data/gridTypeDetector.ts";
-import {
-  indexFromIcechunk,
-  indexFromIndex,
-  indexFromZarr,
-} from "@/lib/data/sourceIndexing.ts";
+import { indexFromIndex, indexFromZarr } from "@/lib/data/sourceIndexing.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import { PROJECTION_TYPES, clamp } from "@/lib/projection/projectionUtils.ts";
 import {
@@ -255,9 +251,7 @@ const updateSrc = async () => {
   // works. If both fail, we log the last error which is from the json-index.
   // This leads to confusing error messages if the zarr source is supposed to
   // work but fails for some reason.
-  const indexPromises = ZarrDataManager.isIcechunkStorePath(src)
-    ? [indexFromIcechunk(src), indexFromZarr(src), indexFromIndex(src)]
-    : [indexFromZarr(src), indexFromIndex(src)];
+  const indexPromises = [indexFromZarr(src), indexFromIndex(src)];
   const indices = await Promise.allSettled(indexPromises);
   let lastError = null;
   store.isInitializingVariable = true;

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -109,7 +109,6 @@ const distractionFree = ref(false);
 const hyperglobeModeActive = ref(false);
 const panelVisibleBeforeDistractionFree = ref(true);
 const globeKey = ref(0);
-const globeControlKey = ref(0);
 const isInitialized = ref(false);
 const sourceValid = ref(false);
 const datasources: Ref<TSources | undefined> = ref(undefined);
@@ -186,7 +185,6 @@ watch(
     // if new data is provided
     detectedGridType.value = undefined;
     globeKey.value += 1;
-    globeControlKey.value += 1;
     if (isDisplayMode.value || isPresenterActive.value) {
       // In display/presenter mode we want to preserve some state across source changes
       store.resetExcept([
@@ -268,6 +266,7 @@ const updateSrc = async () => {
       lastError = index.reason;
     }
   }
+  store.signifyDatasetChange();
   if (!sourceValid.value && lastError) {
     store.stopLoading();
     logError(lastError, "Failed to fetch data");
@@ -404,7 +403,6 @@ useEventListener(window, "keydown", (e: KeyboardEvent) => {
     <Toast />
     <div v-show="!distractionFree && !isDisplayMode">
       <GlobeControls
-        :key="globeControlKey"
         :model-info="modelInfo"
         :current-source="props.src"
         @on-snapshot="makeSnapshot"

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -14,7 +14,11 @@ import {
   GRID_TYPES,
   type T_GRID_TYPES,
 } from "@/lib/data/gridTypeDetector.ts";
-import { indexFromIndex, indexFromZarr } from "@/lib/data/sourceIndexing.ts";
+import {
+  indexFromIcechunk,
+  indexFromIndex,
+  indexFromZarr,
+} from "@/lib/data/sourceIndexing.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import { PROJECTION_TYPES, clamp } from "@/lib/projection/projectionUtils.ts";
 import {
@@ -250,10 +254,10 @@ const updateSrc = async () => {
   // works. If both fail, we log the last error which is from the json-index.
   // This leads to confusing error messages if the zarr source is supposed to
   // work but fails for some reason.
-  const indices = await Promise.allSettled([
-    indexFromZarr(src),
-    indexFromIndex(src),
-  ]);
+  const indexPromises = ZarrDataManager.isIcechunkStorePath(src)
+    ? [indexFromIcechunk(src), indexFromZarr(src), indexFromIndex(src)]
+    : [indexFromZarr(src), indexFromIndex(src)];
+  const indices = await Promise.allSettled(indexPromises);
   let lastError = null;
   store.isInitializingVariable = true;
   sourceValid.value = false;


### PR DESCRIPTION
 Again too many changes at once...

**Features**
*  Control Bar-Elements are collapsible now (#130)
*  Support for icechunk (#124) [Example](https://fix-various.gridlook.pages.dev/#https://dynamical-noaa-gfs.s3.us-west-2.amazonaws.com/noaa-gfs-forecast/v0.2.7.icechunk/::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=wind_u_100m::dimIndices_init_time=0::dimIndices_lead_time=0)
*  Added Fletcher32-Codec (#165)
*  Added QR-Codes to the About-Modal (#147)
*  Added Playbutton on the time dimension (#134)
* added auto-contrast button to colormap which sets bounds to the 2nd to 98th percentile of the data
* ui: replaced checkboxes by toggable buttons for a more "app-like" look and feel. I didn't like the appearance of the checkboxes
* Data-picker-tooltip follows mouse now (#129) 
* Data-picker-tooltip has a small color field now (Credits: Idea by @leifdenby)

**Fixes**
*  `invert` disabled as default (#149)
*  Datapicker no longer shows `0.00000` for very low values (#162)
*  Screenshot projection have now the same width as the colorbar. No empty spaces when colorbar and dataset information are disabled (#164) 
*  implemented all the mentioned better wording in (#157) except for the data picker (to be discussed in future)
*  replaced Primevue Datepicker by vue-datepicker. This should essentially fix all the issues we had with it, including (#145)
*  Center based-alignment for Curvilinear-Grids (#158)
*  Improved rendering for regular grids (fixes #166 and #117) (Credits: @EEholmes and her gridlook fork at https://github.com/eeholmes/gridlook)
* time-dimension is no longer detected by the name "time" but by the unit. Making it work properly with the dynamical datasets where the dimension is always named `init_time` (See Icechunk-Example)
* fixed data picker on touch devices for flat projections (#146) 

Besides those "visible" changes I also did also some rewiring of the control flow during the load of datasets and hopefully simplified it