### PR TITLE
support the dggs zarr convention

### DIFF
--- a/src/lib/data/ZarrDataManager.ts
+++ b/src/lib/data/ZarrDataManager.ts
@@ -150,6 +150,28 @@ export class ZarrDataManager {
     return array;
   }
 
+  static async getParentGroup(
+    datasources: TSources,
+    varname: string,
+    format?: TZarrFormat
+  ): Promise<zarr.Group<zarr.AsyncReadable>> {
+    const groupPath = await ZarrDataManager.resolveGroupPath(varname);
+    const source = ZarrDataManager.getDatasetSource(datasources, varname);
+    const target = (await ZarrDataManager.getDataset(source)).resolve(
+      groupPath
+    );
+
+    let dataset: zarr.Group<zarr.AsyncReadable>;
+    if (format === ZARR_FORMAT.V2) {
+      dataset = await zarr.open.v2(target, { kind: "group" });
+    } else if (format === ZARR_FORMAT.V3) {
+      dataset = await zarr.open.v3(target, { kind: "group" });
+    } else {
+      dataset = await zarr.open(target, { kind: "group" });
+    }
+    return dataset;
+  }
+
   static async getVariableInfoByDatasetSources(
     datasource: TSources,
     variable: string
@@ -233,6 +255,14 @@ export class ZarrDataManager {
       datasources.zarr_format
     );
     return datavar.dimensionNames ?? [];
+  }
+
+  static resolveGroupPath(variable: string): string {
+    if (!variable.includes("/")) {
+      return "/";
+    }
+
+    return variable.split("/").slice(0, -1).join("/");
   }
 
   static resolveVariablePath(

--- a/src/lib/data/gridTypeDetector.ts
+++ b/src/lib/data/gridTypeDetector.ts
@@ -48,7 +48,7 @@ export const GRID_TYPE_DISPLAY_OVERRIDES: Partial<
 async function checkTriangularGrid(
   datasources: TSources | undefined,
   variable: string
-): Promise<boolean> {
+): Promise<T_GRID_TYPES | null> {
   try {
     const gridsource = datasources!.levels[0].grid;
     const resolvedPath = ZarrDataManager.resolveVariablePath(
@@ -60,9 +60,9 @@ async function checkTriangularGrid(
       resolvedPath,
       datasources?.zarr_format
     );
-    return true;
+    return GRID_TYPES.TRIANGULAR;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -107,12 +107,25 @@ function checkGaussianGrid(latitudes: Float64Array, longitudes: Float64Array) {
 
 // Check if grid is regular based on dimension names
 // Also accepts lat-only grids (e.g., zonally averaged data)
-function checkRegularGridFromDimensions(dimensions: string[]): boolean {
+async function checkRegularGridFromDimensions(
+  datasources: TSources,
+  varnameSelector: string
+): Promise<T_GRID_TYPES | null> {
+  const dimensions = await ZarrDataManager.getDimensionNames(
+    datasources!,
+    varnameSelector
+  );
+
   const latitudeIndex = dimensions.findIndex((dim) => isLatitudeName(dim));
   const longitudeIndex = dimensions.findIndex((dim) => isLongitudeName(dim));
   const hasLatLon = latitudeIndex !== -1 && longitudeIndex !== -1;
   const hasLatOnly = latitudeIndex !== -1 && longitudeIndex === -1;
-  return hasLatLon || hasLatOnly;
+
+  if (hasLatLon || hasLatOnly) {
+    return GRID_TYPES.REGULAR;
+  }
+
+  return null;
 }
 
 // Check if grid uses projected x/y coordinates (e.g. EPSG:3857 with spatial_ref)
@@ -146,7 +159,9 @@ async function determineGridTypeFromCRS(
   return null;
 }
 
-function determineGridTypeFromDGGSZarrConvention(metadata: TZarrDggsMetadata) {
+function determineGridTypeFromDGGSZarrConvention(
+  metadata: TZarrDggsMetadata
+): T_GRID_TYPES | null {
   if (metadata["name"] !== "healpix") {
     // unsupported DGGS, for now
     return GRID_TYPES.ERROR;
@@ -166,25 +181,39 @@ async function determineGridTypeFromZarrConvention(
   );
   const metadata = group.attrs;
 
+  if (!("zarr_conventions" in metadata)) {
+    return null;
+  }
+
   const dggsMetadata: TZarrDggsMetadata | unknown = metadata["dggs"];
   if (dggsMetadata) {
     return determineGridTypeFromDGGSZarrConvention(
       dggsMetadata as TZarrDggsMetadata
     );
   }
+
   return null;
 }
 
 // Determine grid type from lat/lon data analysis
 async function determineGridTypeFromData(
-  variable: string,
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  datasources: TSources | undefined,
-  dimensions: string[]
+  datasources: TSources,
+  varnameSelector: string
 ): Promise<T_GRID_TYPES | null> {
+  const dimensions = await ZarrDataManager.getDimensionNames(
+    datasources!,
+    varnameSelector
+  );
+
   try {
+    const datavar = await ZarrDataManager.getVariableInfo(
+      ZarrDataManager.getDatasetSource(datasources!, varnameSelector),
+      varnameSelector,
+      datasources?.zarr_format
+    );
+
     const { latitudes, longitudes } = await getLatLonData(
-      variable,
+      varnameSelector,
       datavar,
       datasources
     );
@@ -211,59 +240,6 @@ async function determineGridTypeFromData(
   }
 }
 
-async function detectGridType(
-  varnameSelector: string,
-  datasources: TSources | undefined
-): Promise<T_GRID_TYPES> {
-  if (await checkTriangularGrid(datasources, varnameSelector)) {
-    return GRID_TYPES.TRIANGULAR;
-  }
-
-  const datavar = await ZarrDataManager.getVariableInfo(
-    ZarrDataManager.getDatasetSource(datasources!, varnameSelector),
-    varnameSelector,
-    datasources?.zarr_format
-  );
-
-  // Check CRS-based grid types
-  const crsGridType = await determineGridTypeFromCRS(
-    datasources!,
-    varnameSelector
-  );
-  if (crsGridType) {
-    return crsGridType;
-  }
-
-  // zarr convention metadata
-  const zarrConventionType = await determineGridTypeFromZarrConvention(
-    datasources!,
-    varnameSelector
-  );
-  if (zarrConventionType) {
-    return zarrConventionType;
-  }
-
-  const dimensions = await ZarrDataManager.getDimensionNames(
-    datasources!,
-    varnameSelector
-  );
-  if (checkRegularGridFromDimensions(dimensions)) {
-    return GRID_TYPES.REGULAR;
-  }
-
-  const dataGridType = await determineGridTypeFromData(
-    varnameSelector,
-    datavar,
-    datasources,
-    dimensions
-  );
-  if (dataGridType) {
-    return dataGridType;
-  }
-
-  return GRID_TYPES.ERROR;
-}
-
 export async function getGridType(
   sourceValid: boolean,
   varnameSelector: string,
@@ -276,12 +252,33 @@ export async function getGridType(
     return GRID_TYPES.ERROR;
   }
 
+  const gridDetectionFunctions: ((
+    datasources: TSources,
+    varnameSelector: string
+  ) => Promise<T_GRID_TYPES | null>)[] = [
+    // Check triangular grids
+    checkTriangularGrid,
+    // Check CRS-based grid types
+    determineGridTypeFromCRS,
+    // zarr convention metadata
+    determineGridTypeFromZarrConvention,
+    checkRegularGridFromDimensions,
+    determineGridTypeFromData,
+  ];
+
   try {
-    const gridType = await detectGridType(varnameSelector, datasources);
-    if (gridType === GRID_TYPES.ERROR) {
-      logError("No matching grid type found", "Could not determine grid type");
+    for (const gridDetectionFunction of gridDetectionFunctions) {
+      const gridType = await gridDetectionFunction(
+        datasources!,
+        varnameSelector
+      );
+      if (gridType) {
+        return gridType;
+      }
     }
-    return gridType;
+
+    logError("No matching grid type found", "Could not determine grid type");
+    return GRID_TYPES.ERROR;
   } catch (error) {
     logError(error, "Could not determine grid type");
     return GRID_TYPES.ERROR;

--- a/src/lib/data/gridTypeDetector.ts
+++ b/src/lib/data/gridTypeDetector.ts
@@ -211,6 +211,59 @@ async function determineGridTypeFromData(
   }
 }
 
+async function detectGridType(
+  varnameSelector: string,
+  datasources: TSources | undefined
+): Promise<T_GRID_TYPES> {
+  if (await checkTriangularGrid(datasources, varnameSelector)) {
+    return GRID_TYPES.TRIANGULAR;
+  }
+
+  const datavar = await ZarrDataManager.getVariableInfo(
+    ZarrDataManager.getDatasetSource(datasources!, varnameSelector),
+    varnameSelector,
+    datasources?.zarr_format
+  );
+
+  // Check CRS-based grid types
+  const crsGridType = await determineGridTypeFromCRS(
+    datasources!,
+    varnameSelector
+  );
+  if (crsGridType) {
+    return crsGridType;
+  }
+
+  // zarr convention metadata
+  const zarrConventionType = await determineGridTypeFromZarrConvention(
+    datasources!,
+    varnameSelector
+  );
+  if (zarrConventionType) {
+    return zarrConventionType;
+  }
+
+  const dimensions = await ZarrDataManager.getDimensionNames(
+    datasources!,
+    varnameSelector
+  );
+  if (checkRegularGridFromDimensions(dimensions)) {
+    return GRID_TYPES.REGULAR;
+  }
+
+  const dataGridType = await determineGridTypeFromData(
+    varnameSelector,
+    datavar,
+    datasources,
+    dimensions
+  );
+  if (dataGridType) {
+    return dataGridType;
+  }
+
+  return GRID_TYPES.ERROR;
+}
+
 export async function getGridType(
   sourceValid: boolean,
   varnameSelector: string,
@@ -223,55 +276,12 @@ export async function getGridType(
     return GRID_TYPES.ERROR;
   }
 
-  if (await checkTriangularGrid(datasources, varnameSelector)) {
-    return GRID_TYPES.TRIANGULAR;
-  }
-
   try {
-    const datavar = await ZarrDataManager.getVariableInfo(
-      ZarrDataManager.getDatasetSource(datasources!, varnameSelector),
-      varnameSelector,
-      datasources?.zarr_format
-    );
-
-    // Check CRS-based grid types
-    const crsGridType = await determineGridTypeFromCRS(
-      datasources!,
-      varnameSelector
-    );
-    if (crsGridType) {
-      return crsGridType;
+    const gridType = await detectGridType(varnameSelector, datasources);
+    if (gridType === GRID_TYPES.ERROR) {
+      logError("No matching grid type found", "Could not determine grid type");
     }
-
-    // zarr convention metadata
-    const zarrConventionType = await determineGridTypeFromZarrConvention(
-      datasources!,
-      varnameSelector
-    );
-    if (zarrConventionType) {
-      return zarrConventionType;
-    }
-
-    const dimensions = await ZarrDataManager.getDimensionNames(
-      datasources!,
-      varnameSelector
-    );
-    if (checkRegularGridFromDimensions(dimensions)) {
-      return GRID_TYPES.REGULAR;
-    }
-
-    const dataGridType = await determineGridTypeFromData(
-      varnameSelector,
-      datavar,
-      datasources,
-      dimensions
-    );
-    if (dataGridType) {
-      return dataGridType;
-    }
-
-    logError("No matching grid type found", "Could not determine grid type");
-    return GRID_TYPES.ERROR;
+    return gridType;
   } catch (error) {
     logError(error, "Could not determine grid type");
     return GRID_TYPES.ERROR;

--- a/src/lib/data/gridTypeDetector.ts
+++ b/src/lib/data/gridTypeDetector.ts
@@ -9,7 +9,7 @@ import {
 } from "./coordinateVariables.ts";
 import { ZarrDataManager } from "./ZarrDataManager.ts";
 
-import type { TSources } from "@/lib/types/GlobeTypes.ts";
+import type { TSources, TZarrDggsMetadata } from "@/lib/types/GlobeTypes.ts";
 
 export const GRID_TYPES = {
   REGULAR: "regular",
@@ -146,7 +146,7 @@ async function determineGridTypeFromCRS(
   return null;
 }
 
-function determineGridTypeFromDGGSZarrConvention(metadata: any) {
+function determineGridTypeFromDGGSZarrConvention(metadata: TZarrDggsMetadata) {
   if (metadata["name"] !== "healpix") {
     // unsupported DGGS, for now
     return GRID_TYPES.ERROR;
@@ -166,8 +166,11 @@ async function determineGridTypeFromZarrConvention(
   );
   const metadata = group.attrs;
 
-  if (metadata["dggs"] !== undefined) {
-    return determineGridTypeFromDGGSZarrConvention(metadata["dggs"]);
+  const dggsMetadata: TZarrDggsMetadata | unknown = metadata["dggs"];
+  if (dggsMetadata) {
+    return determineGridTypeFromDGGSZarrConvention(
+      dggsMetadata as TZarrDggsMetadata
+    );
   }
   return null;
 }

--- a/src/lib/data/gridTypeDetector.ts
+++ b/src/lib/data/gridTypeDetector.ts
@@ -146,6 +146,32 @@ async function determineGridTypeFromCRS(
   return null;
 }
 
+function determineGridTypeFromDGGSZarrConvention(metadata: any) {
+  if (metadata["name"] !== "healpix") {
+    // unsupported DGGS, for now
+    return GRID_TYPES.ERROR;
+  }
+
+  return GRID_TYPES.HEALPIX;
+}
+
+async function determineGridTypeFromZarrConvention(
+  datasources: TSources,
+  varnameSelector: string
+): Promise<T_GRID_TYPES | null> {
+  const group = await ZarrDataManager.getParentGroup(
+    datasources,
+    varnameSelector,
+    datasources?.zarr_format
+  );
+  const metadata = group.attrs;
+
+  if (metadata["dggs"] !== undefined) {
+    return determineGridTypeFromDGGSZarrConvention(metadata["dggs"]);
+  }
+  return null;
+}
+
 // Determine grid type from lat/lon data analysis
 async function determineGridTypeFromData(
   variable: string,
@@ -212,6 +238,15 @@ export async function getGridType(
     );
     if (crsGridType) {
       return crsGridType;
+    }
+
+    // zarr convention metadata
+    const zarrConventionType = await determineGridTypeFromZarrConvention(
+      datasources!,
+      varnameSelector
+    );
+    if (zarrConventionType) {
+      return zarrConventionType;
     }
 
     const dimensions = await ZarrDataManager.getDimensionNames(

--- a/src/lib/types/GlobeTypes.ts
+++ b/src/lib/types/GlobeTypes.ts
@@ -43,6 +43,12 @@ export type TVarInfo = {
   attrs: zarr.Attributes;
 };
 
+export type TZarrDggsMetadata = {
+  name: string;
+  refinement_level: number;
+  coordinate: string | null;
+};
+
 export type TDataSource = {
   store: string;
   dataset: string;

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -33,7 +33,11 @@ import {
   makeGpuProjectedTextureMaterial,
   updateProjectionUniforms,
 } from "@/lib/shaders/gridShaders.ts";
-import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
+import type {
+  TDimensionRange,
+  TSources,
+  TZarrDggsMetadata,
+} from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import {
   HOVERED_GRID_POINT_STATUS,
@@ -176,7 +180,7 @@ async function getNside() {
       props.datasources!,
       varnameSelector.value
     );
-    const metadata: any = group.attrs?.dggs ?? {};
+    const metadata = (group.attrs?.dggs as TZarrDggsMetadata) ?? {};
     if ("refinement_level" in metadata) {
       const refinementLevel = (metadata.refinement_level ?? 0) as number;
       return Math.pow(2, refinementLevel);
@@ -187,17 +191,17 @@ async function getNside() {
 }
 
 async function getCells() {
-  var cellCoord = "cell";
+  let cellCoord = "cell";
   try {
     const group = await ZarrDataManager.getParentGroup(
       props.datasources!,
       varnameSelector.value
     );
-    const metadata: any = group.attrs?.dggs ?? {};
+    const metadata = (group.attrs["dggs"] as TZarrDggsMetadata) ?? {};
 
-    const key = "coordinate";
-    if (key in metadata) {
-      cellCoord = metadata[key];
+    const coordinate = metadata["coordinate"];
+    if (coordinate) {
+      cellCoord = coordinate;
     }
   } catch {
     // no dggs metadata found, continue with the default cell coordinate

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -163,16 +163,46 @@ function fetchGrid() {
 }
 
 async function getNside() {
-  const crs = await ZarrDataManager.getCRSInfo(
-    props.datasources!,
-    varnameSelector.value
-  );
-  // FIXME: could probably have other names
-  const nside = crs.attrs["healpix_nside"] as number;
-  return nside;
+  try {
+    const crs = await ZarrDataManager.getCRSInfo(
+      props.datasources!,
+      varnameSelector.value
+    );
+
+    return crs.attrs["healpix_nside"] as number;
+    // FIXME: could probably have other names
+  } catch (error) {
+    const group = await ZarrDataManager.getParentGroup(
+      props.datasources!,
+      varnameSelector.value
+    );
+    const metadata: any = group.attrs?.dggs ?? {};
+    if ("refinement_level" in metadata) {
+      const refinementLevel = (metadata.refinement_level ?? 0) as number;
+      return Math.pow(2, refinementLevel);
+    }
+
+    throw error;
+  }
 }
 
 async function getCells() {
+  var cellCoord = "cell";
+  try {
+    const group = await ZarrDataManager.getParentGroup(
+      props.datasources!,
+      varnameSelector.value
+    );
+    const metadata: any = group.attrs?.dggs ?? {};
+
+    const key = "coordinate";
+    if (key in metadata) {
+      cellCoord = metadata[key];
+    }
+  } catch {
+    // no dggs metadata found, continue with the default cell coordinate
+  }
+
   try {
     const rawCells = (
       await ZarrDataManager.getVariableData(
@@ -180,7 +210,7 @@ async function getCells() {
           props.datasources!,
           varnameSelector.value
         ),
-        ZarrDataManager.resolveVariablePath(varnameSelector.value, "cell")
+        ZarrDataManager.resolveVariablePath(varnameSelector.value, cellCoord)
       )
     ).data as ArrayLike<number | bigint>;
 


### PR DESCRIPTION
This adds support for reading healpix metadata from the [zarr dggs convention](https://github.com/zarr-conventions/dggs).

While this works, I'm not quite sure this is the best way to implement this: the metadata is fetched multiple times. I would personally prefer to fetch it once then, then return it along with the grid type from `getGridType` in a standardized metadata object. An additional benefit would be that adding support for other conventions (e.g. the cf convention's `healpix` mapping) becomes easier, as well.

For example, I'd imagine that object to be something like this:
```ts
{
  "level": refinement_level,
  "indexing_scheme": indexing_scheme,
  "coordinate": coordinate_name,
}
```
What we need here is some information about the level / nside, the indexing scheme / cell ordering, and the name of the coordinate variable, which can be `null` for full-earth coverage.

Also, I'm much more used to `level` so I used that in the example, but `nside = Math.pow(2, level)`, so `nside` would work, too. I believe only `indexing_scheme == "nested"` is supported for now, so you could omit that for now.

cc @Karinon