### PR TITLE
feat: add loco support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ https://gridlook.pages.dev/#<ZARR_URI>
 
 Gridlook can also load catalog JSON files that list multiple datasets. The catalog format and deployment options are documented in [docs/catalogs.md](docs/catalogs.md).
 
+Gridlook can follow **live datasets** (a Zarr store where only the current timestep is available, updated as a simulation runs) by appending `::live=true` to the dataset URL. See [docs/live-datasets.md](docs/live-datasets.md).
+
 A guide to the viewer keyboard, mouse, and touch interaction is available in [docs/Controls.md](docs/Controls.md).
 
 ## Project Setup

--- a/docs/live-datasets.md
+++ b/docs/live-datasets.md
@@ -1,0 +1,71 @@
+# Live Datasets
+
+Gridlook can follow a **live dataset**: a Zarr store whose time axis is fully
+declared up front, but where only the currently-available timestep can actually
+be fetched at any moment. This is useful for viewing a running simulation or a
+rolling forecast as new output appears.
+
+## Enabling live mode
+
+Append the `live=true` parameter to the dataset hash:
+
+```text
+https://gridlook.pages.dev/#<ZARR_URI>::live=true
+```
+
+When live mode is active, Gridlook:
+
+1. Fetches the currently-available timestep and jumps the time slider to it.
+2. Long-polls for the next timestep and, whenever a newer one becomes available,
+   re-fetches and re-renders that timestep automatically.
+3. Locks the time slider to the live timestep (only one timestep is fetchable at
+   a time) and shows a **LIVE** badge with a pause/resume control.
+
+Pausing freezes the currently displayed frame; resuming jumps back to the newest
+available timestep and continues following.
+
+Live mode is only supported for datasets served over plain HTTP (Zarr
+`FetchStore`), not for Icechunk stores.
+
+## Server contract
+
+The data server must expose two endpoints **next to the Zarr store root**, i.e.
+as siblings of the store's metadata:
+
+| Endpoint           | Behaviour                                                     |
+| ------------------ | ------------------------------------------------------------- |
+| `current-timestep` | Responds **immediately** with the index available right now.  |
+| `next-timestep`    | **Long-polls**: responds only once a newer timestep is ready. |
+
+For a store at `https://host/data.zarr`, Gridlook requests
+`https://host/data.zarr/current-timestep` and
+`https://host/data.zarr/next-timestep`.
+
+Both endpoints must return JSON of the form:
+
+```json
+{ "timestep": 42 }
+```
+
+where `timestep` is a non-negative integer index into the store's (fixed) time
+dimension. The chunk data for that timestep must be fetchable at the moment the
+endpoint reports it; earlier/later timesteps may be unavailable.
+
+### Assumptions
+
+- The Zarr array's `shape` and the `time` coordinate values cover the whole run
+  and are readable up front. Only the **data-variable chunks** lag — they become
+  fetchable once their timestep is reported.
+- The reported index is a valid index into that fixed time axis.
+
+### Error handling
+
+If `next-timestep` fails (network drop, `5xx`, missing endpoint), Gridlook
+retries with exponential backoff (1s → 30s cap) and shows a subtle
+"Reconnecting…" indicator until the connection recovers.
+
+### CORS
+
+As with any dataset, the store and both timestep endpoints must be reachable
+from the browser and CORS-enabled when hosted on another origin. See the CORS
+notes in the [README](../README.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,7 +581,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -593,7 +592,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -604,7 +602,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1009,7 +1006,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -1048,7 +1044,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,7 +1064,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1090,7 +1084,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,7 +1104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1132,7 +1124,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,7 +1144,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,7 +1164,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,7 +1184,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,7 +1204,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1236,7 +1223,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1256,7 +1242,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,7 +1262,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1298,7 +1282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1419,7 +1402,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1436,7 +1418,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1453,7 +1434,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,7 +1450,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,7 +1466,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,7 +1482,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,7 +1498,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,7 +1514,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,7 +1530,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,7 +1546,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,7 +1562,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,7 +1578,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,7 +1594,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1639,7 +1609,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1661,7 +1630,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1678,7 +1646,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1823,7 +1790,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1906,7 +1872,7 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3333,7 +3299,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3477,7 +3443,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4127,7 +4093,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -5042,7 +5007,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5159,7 +5124,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5860,7 +5824,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6084,7 +6048,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6145,7 +6109,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6183,7 +6147,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6401,7 +6365,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6549,7 +6513,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6570,7 +6533,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6591,7 +6553,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6612,7 +6573,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6633,7 +6593,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6654,7 +6613,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6675,7 +6633,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6696,7 +6653,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6717,7 +6673,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6738,7 +6693,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6759,7 +6713,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7059,7 +7012,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -7228,7 +7181,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "optional": true
     },
     "node_modules/nth-check": {
@@ -7562,7 +7514,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8014,7 +7966,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -8304,7 +8256,7 @@
       "version": "1.89.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -8969,7 +8921,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -9186,7 +9138,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,6 +581,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -592,6 +593,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -602,6 +604,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1006,6 +1009,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -1044,6 +1048,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,6 +1069,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1084,6 +1090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,6 +1111,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,6 +1132,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,6 +1153,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1164,6 +1174,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,6 +1195,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,6 +1216,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1223,6 +1236,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1242,6 +1256,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1277,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1282,6 +1298,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,6 +1419,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1418,6 +1436,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1434,6 +1453,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,6 +1470,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,6 +1487,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1482,6 +1504,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,6 +1521,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,6 +1538,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,6 +1555,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1546,6 +1572,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,6 +1589,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,6 +1606,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,6 +1623,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1609,6 +1639,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1630,6 +1661,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1646,6 +1678,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1790,6 +1823,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1872,7 +1906,7 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3299,7 +3333,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3443,7 +3477,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4093,6 +4127,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -5007,7 +5042,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5124,6 +5159,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5824,7 +5860,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6048,7 +6084,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6109,7 +6145,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6147,7 +6183,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6365,7 +6401,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6513,6 +6549,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6533,6 +6570,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6553,6 +6591,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6573,6 +6612,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6593,6 +6633,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6613,6 +6654,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6633,6 +6675,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6653,6 +6696,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6673,6 +6717,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6693,6 +6738,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6713,6 +6759,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7012,7 +7059,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -7181,6 +7228,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/nth-check": {
@@ -7514,7 +7562,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7966,7 +8014,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -8256,7 +8304,7 @@
       "version": "1.89.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -8921,7 +8969,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -9138,7 +9186,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {

--- a/src/lib/data/liveTimestep.ts
+++ b/src/lib/data/liveTimestep.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 import { parseStorePath } from "./icechunkStore.ts";
 
 import type { TSources } from "@/lib/types/GlobeTypes.ts";
@@ -62,13 +64,20 @@ async function fetchTimestep(
   url: string,
   signal: AbortSignal
 ): Promise<number> {
-  const response = await fetch(url, { signal, cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(
-      `Timestep endpoint ${url} returned HTTP ${response.status}`
-    );
+  let body: TTimestepResponse;
+  try {
+    const response = await axios.get<TTimestepResponse>(url, {
+      signal,
+      headers: { "Cache-Control": "no-store" },
+    });
+    body = response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const { status } = error.response;
+      throw new Error(`Timestep endpoint ${url} returned HTTP ${status}`);
+    }
+    throw error;
   }
-  const body = (await response.json()) as TTimestepResponse;
   const timestep = parseTimestep(body?.timestep);
   if (timestep === null) {
     throw new Error(
@@ -103,7 +112,10 @@ export function fetchNextTimestep(
 }
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
+  return (
+    axios.isCancel(error) ||
+    (error instanceof DOMException && error.name === "AbortError")
+  );
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/src/lib/data/liveTimestep.ts
+++ b/src/lib/data/liveTimestep.ts
@@ -1,0 +1,212 @@
+import { parseStorePath } from "./icechunkStore.ts";
+
+import type { TSources } from "@/lib/types/GlobeTypes.ts";
+
+/**
+ * "Live" datasets expose only the currently-available timestep of an otherwise
+ * fully-declared Zarr store. Two HTTP endpoints, served next to the store root,
+ * describe which timestep can be fetched right now:
+ *
+ * - `current-timestep` responds immediately with the index available now.
+ * - `next-timestep` long-polls and only responds once a newer timestep becomes
+ *   available.
+ *
+ * Both return JSON of the form `{ "timestep": <index> }`, where the index is a
+ * valid index into the store's (fixed) time dimension.
+ */
+export const CURRENT_TIMESTEP_ENDPOINT = "current-timestep";
+export const NEXT_TIMESTEP_ENDPOINT = "next-timestep";
+
+/**
+ * Resolve the base HTTP URL of the Zarr store backing a live dataset.
+ * Live mode is only supported for plain HTTP (`FetchStore`) datasets, so this
+ * returns `undefined` for icechunk stores.
+ */
+export function liveStoreBaseUrl(datasources: TSources): string | undefined {
+  const level = datasources.levels[0];
+  const store = level?.time?.store ?? level?.grid?.store;
+  if (!store) {
+    return undefined;
+  }
+  const { backend, url } = parseStorePath(store);
+  if (backend !== "fetch") {
+    return undefined;
+  }
+  return url.replace(/\/+$/, "");
+}
+
+/** Join the store base URL with a timestep endpoint name. */
+export function timestepEndpointUrl(baseUrl: string, endpoint: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${endpoint}`;
+}
+
+type TTimestepResponse = { timestep?: unknown };
+
+/**
+ * Coerce the `timestep` field into a non-negative integer. Accepts either a
+ * JSON number (`{"timestep": 42}`) or a numeric string (`{"timestep": "42"}`),
+ * since servers differ in how they encode it.
+ */
+function parseTimestep(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+  }
+  return null;
+}
+
+async function fetchTimestep(
+  url: string,
+  signal: AbortSignal
+): Promise<number> {
+  const response = await fetch(url, { signal, cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(
+      `Timestep endpoint ${url} returned HTTP ${response.status}`
+    );
+  }
+  const body = (await response.json()) as TTimestepResponse;
+  const timestep = parseTimestep(body?.timestep);
+  if (timestep === null) {
+    throw new Error(
+      `Timestep endpoint ${url} returned an invalid payload: ${JSON.stringify(
+        body
+      )}`
+    );
+  }
+  return timestep;
+}
+
+/** Fetch the currently-available timestep. Responds immediately. */
+export function fetchCurrentTimestep(
+  baseUrl: string,
+  signal: AbortSignal
+): Promise<number> {
+  return fetchTimestep(
+    timestepEndpointUrl(baseUrl, CURRENT_TIMESTEP_ENDPOINT),
+    signal
+  );
+}
+
+/** Long-poll for the next timestep. Resolves once a newer one is available. */
+export function fetchNextTimestep(
+  baseUrl: string,
+  signal: AbortSignal
+): Promise<number> {
+  return fetchTimestep(
+    timestepEndpointUrl(baseUrl, NEXT_TIMESTEP_ENDPOINT),
+    signal
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+export type TLiveTimestepControllerOptions = {
+  /** Base HTTP URL of the live store (see {@link liveStoreBaseUrl}). */
+  baseUrl: string;
+  /** Called with each timestep index that becomes available (newest first). */
+  onTimestep: (timestep: number) => void;
+  /** Notified when the long-poll connection is established or lost. */
+  onConnectedChange?: (connected: boolean) => void;
+  /** Notified about transient errors while (re)connecting. */
+  onError?: (error: unknown) => void;
+  /** Initial reconnect delay in ms (default 1000). */
+  minBackoffMs?: number;
+  /** Maximum reconnect delay in ms (default 30000). */
+  maxBackoffMs?: number;
+};
+
+const DEFAULT_MIN_BACKOFF_MS = 1000;
+const DEFAULT_MAX_BACKOFF_MS = 30000;
+
+/**
+ * Drives auto-following of a live dataset. On {@link start} it fetches the
+ * current timestep immediately, then keeps long-polling `next-timestep`,
+ * emitting each new index through `onTimestep`. Transient failures are retried
+ * with exponential backoff. Call {@link stop} to abort any in-flight request
+ * and end the loop; pausing/resuming is modelled by stopping and creating a new
+ * controller.
+ */
+export class LiveTimestepController {
+  private readonly options: TLiveTimestepControllerOptions;
+  private readonly abortController = new AbortController();
+  private stopped = false;
+  private started = false;
+
+  constructor(options: TLiveTimestepControllerOptions) {
+    this.options = options;
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    void this.run();
+  }
+
+  stop(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    this.abortController.abort();
+    this.options.onConnectedChange?.(false);
+  }
+
+  private async run(): Promise<void> {
+    const signal = this.abortController.signal;
+    const minBackoff = this.options.minBackoffMs ?? DEFAULT_MIN_BACKOFF_MS;
+    const maxBackoff = this.options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+    let backoff = minBackoff;
+    // Fetch the current timestep first so we jump straight to the newest data,
+    // then switch to long-polling for subsequent ones.
+    let fetchCurrent = true;
+
+    while (!this.stopped) {
+      try {
+        const timestep = fetchCurrent
+          ? await fetchCurrentTimestep(this.options.baseUrl, signal)
+          : await fetchNextTimestep(this.options.baseUrl, signal);
+        if (this.stopped) {
+          return;
+        }
+        this.options.onConnectedChange?.(true);
+        backoff = minBackoff;
+        fetchCurrent = false;
+        this.options.onTimestep(timestep);
+      } catch (error) {
+        if (this.stopped || isAbortError(error)) {
+          return;
+        }
+        this.options.onConnectedChange?.(false);
+        this.options.onError?.(error);
+        await sleep(backoff, signal);
+        backoff = Math.min(backoff * 2, maxBackoff);
+      }
+    }
+  }
+}

--- a/src/store/paramStore.ts
+++ b/src/store/paramStore.ts
@@ -34,6 +34,7 @@ export const useUrlParameterStore = defineStore("urlParams", {
       paramProjectionCenterLon: undefined as string | undefined,
       paramGridType: undefined as string | undefined,
       paramCatalog: undefined as string | undefined,
+      paramLive: undefined as string | undefined,
     };
   },
   actions: {
@@ -79,4 +80,5 @@ export const STORE_PARAM_MAPPING = {
   boundhigh: "paramBoundHigh",
   gridtype: "paramGridType",
   catalog: "paramCatalog",
+  live: "paramLive",
 } as const;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -169,6 +169,13 @@ export const useGlobeControlStore = defineStore("globeControl", {
       hoveredGridPoint: undefined as THoveredGridPoint | undefined,
       catalogUrl: undefined as string | undefined,
       catalogData: undefined as TCatalog | undefined,
+      // ── Live datasets ──────────────────────────────────────────────
+      // A live dataset exposes only the currently-available timestep and is
+      // followed automatically by polling the store's timestep endpoints.
+      live: false, // whether the current dataset is a live dataset
+      livePaused: false, // user paused auto-following the newest timestep
+      liveConnected: false, // whether the long-poll is currently connected
+      liveTimestep: undefined as number | undefined, // latest known live index
       // layer panel stack, ordered top → bottom; order determines render order
       layerStack: builtinLayerStack() as TLayerEntry[],
       // incremented to request a GeoTIFF image-layer export of the current grid
@@ -213,6 +220,23 @@ export const useGlobeControlStore = defineStore("globeControl", {
     },
     toggleRotating() {
       this.isRotating = !this.isRotating;
+    },
+    setLive(live: boolean) {
+      this.live = live;
+      if (!live) {
+        this.livePaused = false;
+        this.liveConnected = false;
+        this.liveTimestep = undefined;
+      }
+    },
+    toggleLivePaused() {
+      this.livePaused = !this.livePaused;
+    },
+    setLiveConnected(connected: boolean) {
+      this.liveConnected = connected;
+    },
+    setLiveTimestep(timestep: number) {
+      this.liveTimestep = timestep;
     },
     toggleHoverEnabled() {
       this.hoverEnabled = !this.hoverEnabled;

--- a/src/store/useLiveTimestep.ts
+++ b/src/store/useLiveTimestep.ts
@@ -1,0 +1,96 @@
+import { onScopeDispose, watch, type Ref } from "vue";
+
+import {
+  LiveTimestepController,
+  liveStoreBaseUrl,
+} from "@/lib/data/liveTimestep.ts";
+import type { TSources } from "@/lib/types/GlobeTypes.ts";
+import { useGlobeControlStore } from "@/store/store.ts";
+
+type TGlobeControlStore = ReturnType<typeof useGlobeControlStore>;
+
+function timeDimensionIndex(store: TGlobeControlStore): number {
+  const ranges = store.varinfo?.dimRanges;
+  if (!ranges) {
+    return -1;
+  }
+  return ranges.findIndex((range) => range?.name === "time");
+}
+
+function makeController(
+  store: TGlobeControlStore,
+  baseUrl: string,
+  index: number
+): LiveTimestepController {
+  return new LiveTimestepController({
+    baseUrl,
+    onTimestep: (timestep) => {
+      store.setLiveTimestep(timestep);
+      // Writing the time slider triggers the grid data loader to refetch and
+      // re-render at the (now available) timestep.
+      if (store.dimSlidersValues[index] !== timestep) {
+        store.dimSlidersValues[index] = timestep;
+      }
+    },
+    onConnectedChange: (connected) => store.setLiveConnected(connected),
+    onError: (error) =>
+      console.warn("Live timestep polling failed; retrying.", error),
+  });
+}
+
+/**
+ * Auto-follows the newest available timestep of a live dataset.
+ *
+ * When {@link useGlobeControlStore().live} is set and not paused, this starts a
+ * {@link LiveTimestepController} for the current store. Each new timestep index
+ * is written into the time slider (`dimSlidersValues`), which the grid data
+ * loader already watches, so the grid refetches and re-renders the newly
+ * available data. Pausing tears the controller down; resuming spins up a fresh
+ * one that jumps straight to the current timestep.
+ */
+export function useLiveTimestep(datasources: Ref<TSources | undefined>) {
+  const store = useGlobeControlStore();
+  let controller: LiveTimestepController | null = null;
+  let activeIndex = -1;
+  let activeBaseUrl: string | undefined;
+
+  function stopController() {
+    controller?.stop();
+    controller = null;
+    activeIndex = -1;
+    activeBaseUrl = undefined;
+    store.setLiveConnected(false);
+  }
+
+  function sync() {
+    const sources = datasources.value;
+    const index = timeDimensionIndex(store);
+    const baseUrl = sources ? liveStoreBaseUrl(sources) : undefined;
+    // Not live, paused, not a live-capable store, or time dimension unknown yet.
+    if (!store.live || store.livePaused || !baseUrl || index === -1) {
+      stopController();
+      return;
+    }
+    if (controller && activeIndex === index && activeBaseUrl === baseUrl) {
+      return; // already following this store/dimension
+    }
+    stopController();
+    activeIndex = index;
+    activeBaseUrl = baseUrl;
+    controller = makeController(store, baseUrl, index);
+    controller.start();
+  }
+
+  watch(
+    () => [
+      store.live,
+      store.livePaused,
+      datasources.value,
+      timeDimensionIndex(store),
+    ],
+    sync,
+    { immediate: true }
+  );
+
+  onScopeDispose(stopController);
+}

--- a/src/store/useUrlSync.ts
+++ b/src/store/useUrlSync.ts
@@ -177,6 +177,11 @@ export function useUrlSync() {
         if (dimension[i] === null) {
           continue;
         }
+        // In live mode the time index is driven by polling and re-seeded from
+        // the server on load, so keep it out of the shareable URL.
+        if (store.live && dimension[i]?.name === "time") {
+          continue;
+        }
         const val = store.dimSlidersDisplay[i];
         if (val !== null) {
           dimensionValues[`dimIndices_${dimension[i]?.name}` as string] = val;

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -165,28 +165,78 @@ function fetchGrid() {
   }
 }
 
-async function getNside() {
-  try {
-    const crs = await ZarrDataManager.getCRSInfo(
-      props.datasources!,
-      varnameSelector.value
-    );
+function coerceNside(value: unknown): number | null {
+  const nside = typeof value === "number" ? value : Number(value);
+  return Number.isInteger(nside) && nside > 0 ? nside : null;
+}
 
-    return crs.attrs["healpix_nside"] as number;
-    // FIXME: could probably have other names
-  } catch (error) {
+async function nsideFromDggsMetadata(): Promise<number | null> {
+  try {
     const group = await ZarrDataManager.getParentGroup(
       props.datasources!,
       varnameSelector.value
     );
     const metadata = (group.attrs?.dggs as TZarrDggsMetadata) ?? {};
-    if ("refinement_level" in metadata) {
-      const refinementLevel = (metadata.refinement_level ?? 0) as number;
-      return Math.pow(2, refinementLevel);
+    const level = metadata.refinement_level;
+    if (level !== null && level !== undefined) {
+      return Math.pow(2, Number(level));
     }
-
-    throw error;
+  } catch {
+    // no dggs metadata found
   }
+  return null;
+}
+
+/**
+ * Derive nside from the length of the (last) cell dimension, assuming a global
+ * grid where `ncells = 12 * nside^2`. Returns null unless that yields an exact
+ * positive integer nside, so it never misfires on limited-area data.
+ */
+function nsideFromCellCount(
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
+): number | null {
+  const ncells = datavar.shape[datavar.shape.length - 1];
+  if (!ncells) {
+    return null;
+  }
+  return coerceNside(Math.sqrt(ncells / 12));
+}
+
+async function getNside(
+  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
+): Promise<number> {
+  // Preferred: `healpix_nside` on the grid-mapping / CRS variable.
+  try {
+    const crs = await ZarrDataManager.getCRSInfo(
+      props.datasources!,
+      varnameSelector.value
+    );
+    const fromCrs = coerceNside(crs.attrs["healpix_nside"]);
+    if (fromCrs !== null) {
+      return fromCrs;
+    }
+    // CRS variable exists but has no usable nside; fall through to dggs.
+  } catch {
+    // No CRS variable; fall through to dggs metadata.
+  }
+
+  // Fallback: derive nside from the group's DGGS refinement level.
+  const fromDggs = await nsideFromDggsMetadata();
+  if (fromDggs !== null) {
+    return fromDggs;
+  }
+
+  // Last resort: infer nside from a global grid's cell count (12 * nside^2).
+  const fromShape = nsideFromCellCount(datavar);
+  if (fromShape !== null) {
+    return fromShape;
+  }
+
+  throw new Error(
+    "Could not determine HEALPix nside: no valid `healpix_nside` on the " +
+      "grid-mapping variable, no `dggs.refinement_level` on the group, and " +
+      "the cell-dimension length is not 12 * nside^2."
+  );
 }
 
 async function getCells() {
@@ -693,7 +743,7 @@ async function fetchAndRenderData(
   const { dimensionRanges, indices } = await prepareDimensionData(datavar);
 
   const cellCoord = await getCells();
-  const nside = await getNside();
+  const nside = await getNside(datavar);
   hoverNside.value = nside;
   hoverData.value = castDataVarToFloat32(
     (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data

--- a/src/ui/overlays/controls/DimensionControl.vue
+++ b/src/ui/overlays/controls/DimensionControl.vue
@@ -10,7 +10,8 @@ import { decodeTime, isTimeUnits } from "@/lib/data/timeHandling.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
 
 const store = useGlobeControlStore();
-const { varinfo, dimSlidersValues } = storeToRefs(store);
+const { varinfo, dimSlidersValues, live, livePaused, liveConnected } =
+  storeToRefs(store);
 
 const { isPlaying, canAnimate, toggle, cycleSpeed, speedLabel } =
   useTimeAnimation();
@@ -108,6 +109,12 @@ function formatCurrentValue(index: number) {
 function capitalize(str: string): string {
   return String(str[0]).toUpperCase() + String(str).slice(1);
 }
+
+// While live-following, the time dimension is driven by polling and must not be
+// scrubbed manually (only the current timestep is available).
+function isLiveTime(index: number): boolean {
+  return live.value && isTimeDimension(index);
+}
 </script>
 
 <template>
@@ -133,7 +140,7 @@ function capitalize(str: string): string {
           <div class="is-flex is-align-items-center" style="gap: 0.5rem">
             {{ capitalize(range.name) }}:
             <DatetimePicker
-              v-if="isTimeDimension(index)"
+              v-if="isTimeDimension(index) && !isLiveTime(index)"
               :time-values="varinfo.dimInfo[index]?.values ?? []"
               :time-attrs="varinfo.dimInfo[index]?.attrs ?? {}"
               :current-index="localSliders[index] ?? 0"
@@ -149,6 +156,7 @@ function capitalize(str: string): string {
               type="number"
               :min="range.minBound"
               :max="range.maxBound"
+              :disabled="isLiveTime(index)"
               style="width: 8em"
             />
             <div class="my-2 ml-2">/ {{ range.maxBound }}</div>
@@ -161,10 +169,40 @@ function capitalize(str: string): string {
           type="range"
           :min="range.minBound"
           :max="range.maxBound"
+          :disabled="isLiveTime(index)"
         />
 
+        <!-- Live-follow controls (replace playback controls for live datasets) -->
         <div
-          v-if="isTimeDimension(index) && canAnimate"
+          v-if="isLiveTime(index)"
+          class="is-flex is-align-items-center mt-2"
+          style="gap: 0.5rem"
+        >
+          <span class="tag is-danger">
+            <span class="icon is-small">
+              <i class="fas fa-circle"></i>
+            </span>
+            <span>LIVE</span>
+          </span>
+          <button
+            class="button is-small"
+            :class="{ 'is-info': livePaused }"
+            type="button"
+            :title="livePaused ? 'Resume live updates' : 'Pause live updates'"
+            @click="store.toggleLivePaused()"
+          >
+            <span class="icon">
+              <i :class="livePaused ? 'fas fa-play' : 'fas fa-pause'"></i>
+            </span>
+          </button>
+          <span v-if="livePaused" class="is-size-7 has-text-grey">Paused</span>
+          <span v-else-if="!liveConnected" class="is-size-7 has-text-grey">
+            Reconnecting…
+          </span>
+        </div>
+
+        <div
+          v-if="isTimeDimension(index) && canAnimate && !isLiveTime(index)"
           class="is-flex is-align-items-center mt-2"
           style="gap: 0.5rem"
         >

--- a/src/ui/overlays/controls/useTimeAnimation.ts
+++ b/src/ui/overlays/controls/useTimeAnimation.ts
@@ -65,6 +65,7 @@ type TAnimationStoreRefs = {
   varinfo: Ref<TVarInfo | undefined>;
   dimSlidersValues: Ref<(number | null)[]>;
   loading: Ref<boolean>;
+  live: Ref<boolean>;
 };
 
 function createTimeRangeIndex(varinfo: Ref<TVarInfo | undefined>) {
@@ -97,7 +98,10 @@ function createTimeAnimationContext(
   });
   const canAnimate = computed(() => {
     const range = timeRange.value;
-    return range !== null && range.maxBound > range.minBound;
+    // Live datasets are driven by polling, not manual playback.
+    return (
+      !refs.live.value && range !== null && range.maxBound > range.minBound
+    );
   });
 
   return {
@@ -177,11 +181,12 @@ function createPlaybackControls(ctx: TAnimationContext) {
 
 export function useTimeAnimation() {
   const store = useGlobeControlStore();
-  const { varinfo, dimSlidersValues, loading } = storeToRefs(store);
+  const { varinfo, dimSlidersValues, loading, live } = storeToRefs(store);
   const animationContext = createTimeAnimationContext({
     varinfo,
     dimSlidersValues,
     loading,
+    live,
   });
 
   const { stop, toggle, cycleSpeed, scheduleNextStep } =

--- a/src/utils/urlParams.ts
+++ b/src/utils/urlParams.ts
@@ -19,6 +19,7 @@ const URL_PARAMETERS = {
   DIM_INDICES: "dimIndices",
   DIM_MIN_BOUNDS: "dimMinBounds",
   DIM_MAX_BOUNDS: "dimMaxBounds",
+  LIVE: "live",
 } as const;
 
 type TURLParameterValues = (typeof URL_PARAMETERS)[keyof typeof URL_PARAMETERS];

--- a/src/views/GlobeView.vue
+++ b/src/views/GlobeView.vue
@@ -14,6 +14,10 @@ import {
   GRID_TYPES,
   type T_GRID_TYPES,
 } from "@/lib/data/gridTypeDetector.ts";
+import {
+  fetchCurrentTimestep,
+  liveStoreBaseUrl,
+} from "@/lib/data/liveTimestep.ts";
 import { indexFromIndex, indexFromZarr } from "@/lib/data/sourceIndexing.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import { PROJECTION_TYPES, clamp } from "@/lib/projection/projectionUtils.ts";
@@ -24,6 +28,7 @@ import {
 import { PresenterRole } from "@/lib/types/presenterSync.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
+import { useLiveTimestep } from "@/store/useLiveTimestep.ts";
 import {
   usePresenterSync,
   isDisplayMode,
@@ -91,7 +96,7 @@ if (urlParams.get("mode") === PresenterRole.DISPLAY) {
 const { varnameSelector, loading, colormap, invertColormap } =
   storeToRefs(store);
 
-const { paramVarname, paramGridType, paramDistractionFree } =
+const { paramVarname, paramGridType, paramDistractionFree, paramLive } =
   storeToRefs(urlParameterStore);
 
 type TGlobeHandle = {
@@ -120,6 +125,9 @@ const sourceValid = ref(false);
 const datasources: Ref<TSources | undefined> = ref(undefined);
 const detectedGridType: Ref<T_GRID_TYPES | undefined> = ref(undefined);
 const infoPanelOpen = ref(false);
+
+// Auto-follow the newest timestep of a live dataset (see useLiveTimestep).
+useLiveTimestep(datasources);
 
 const distractionFreeFromUrl = paramDistractionFree.value === "true";
 
@@ -319,9 +327,45 @@ async function updateSrc(updateId: number) {
       lastError = index.reason;
     }
   }
+  store.setLive(paramLive.value === "true");
+  if (store.live && sourceValid.value && datasources.value) {
+    await seedLiveTimestep(datasources.value, updateId);
+  }
   store.signifyDatasetChange();
   if (!sourceValid.value && lastError) {
     logError(lastError, "Failed to fetch data");
+  }
+}
+
+/**
+ * Fetch the currently-available timestep of a live dataset and use it as the
+ * initial time index, so the first render requests a chunk that actually
+ * exists. Best-effort: on failure the live controller will still recover by
+ * retrying once it starts. Bounded by a timeout so a stuck endpoint cannot
+ * block the whole dataset from loading.
+ */
+async function seedLiveTimestep(sources: TSources, updateId: number) {
+  const baseUrl = liveStoreBaseUrl(sources);
+  if (!baseUrl) {
+    return;
+  }
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 10000);
+  try {
+    const current = await fetchCurrentTimestep(baseUrl, abortController.signal);
+    if (updateId !== sourceUpdateId) {
+      return;
+    }
+    urlParameterStore.paramDimIndices["time"] = String(current);
+    store.setLiveTimestep(current);
+  } catch (error) {
+    logError(
+      error,
+      `Live dataset: could not reach ${baseUrl}/current-timestep ` +
+        `(check the endpoint is served next to the store and CORS-enabled)`
+    );
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/tests/unit/lib/data/liveTimestep.test.ts
+++ b/tests/unit/lib/data/liveTimestep.test.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError, AxiosHeaders } from "axios";
 import { afterEach, expect, it, vi } from "vitest";
 
 import {
@@ -22,16 +23,11 @@ function makeSources(store: string): TSources {
   };
 }
 
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return { ok, status, json: async () => body } as unknown as Response;
-}
-
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 const signal = new AbortController().signal;
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 it("joins the base URL and endpoint, normalizing trailing slashes", () => {
@@ -56,43 +52,47 @@ it("returns undefined for an icechunk store (live mode is HTTP-only)", () => {
 });
 
 it("parses the timestep from the current-timestep endpoint", async () => {
-  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ timestep: 7 }));
-  vi.stubGlobal("fetch", fetchMock);
+  const getMock = vi
+    .spyOn(axios, "get")
+    .mockResolvedValue({ data: { timestep: 7 } });
 
   await expect(fetchCurrentTimestep("https://h/d.zarr", signal)).resolves.toBe(
     7
   );
-  expect(fetchMock).toHaveBeenCalledWith(
+  expect(getMock).toHaveBeenCalledWith(
     "https://h/d.zarr/current-timestep",
     expect.objectContaining({ signal })
   );
 });
 
 it("accepts a numeric string in the timestep field", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue(jsonResponse({ timestep: "42" }))
-  );
+  vi.spyOn(axios, "get").mockResolvedValue({ data: { timestep: "42" } });
   await expect(fetchCurrentTimestep("https://h/d.zarr", signal)).resolves.toBe(
     42
   );
 });
 
 it("long-polls the next-timestep endpoint", async () => {
-  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ timestep: 8 }));
-  vi.stubGlobal("fetch", fetchMock);
+  const getMock = vi
+    .spyOn(axios, "get")
+    .mockResolvedValue({ data: { timestep: 8 } });
 
   await expect(fetchNextTimestep("https://h/d.zarr", signal)).resolves.toBe(8);
-  expect(fetchMock).toHaveBeenCalledWith(
+  expect(getMock).toHaveBeenCalledWith(
     "https://h/d.zarr/next-timestep",
     expect.objectContaining({ signal })
   );
 });
 
 it("throws on a non-OK response", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue(jsonResponse({}, false, 503))
+  vi.spyOn(axios, "get").mockRejectedValue(
+    new AxiosError("Request failed", undefined, undefined, undefined, {
+      status: 503,
+      data: {},
+      statusText: "Service Unavailable",
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    })
   );
   await expect(
     fetchCurrentTimestep("https://h/d.zarr", signal)
@@ -100,20 +100,14 @@ it("throws on a non-OK response", async () => {
 });
 
 it("throws on an invalid payload", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue(jsonResponse({ timestep: "nope" }))
-  );
+  vi.spyOn(axios, "get").mockResolvedValue({ data: { timestep: "nope" } });
   await expect(
     fetchCurrentTimestep("https://h/d.zarr", signal)
   ).rejects.toThrow(/invalid payload/);
 });
 
 it("rejects negative or non-integer timesteps", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue(jsonResponse({ timestep: -1 }))
-  );
+  vi.spyOn(axios, "get").mockResolvedValue({ data: { timestep: -1 } });
   await expect(
     fetchCurrentTimestep("https://h/d.zarr", signal)
   ).rejects.toThrow(/invalid payload/);
@@ -122,17 +116,16 @@ it("rejects negative or non-integer timesteps", async () => {
 it("emits the current timestep first, then follows subsequent ones", async () => {
   // current-timestep -> 5, next-timestep -> 6, then park (never resolves).
   let call = 0;
-  const fetchMock = vi.fn().mockImplementation(() => {
+  const getMock = vi.spyOn(axios, "get").mockImplementation(() => {
     call += 1;
     if (call === 1) {
-      return Promise.resolve(jsonResponse({ timestep: 5 }));
+      return Promise.resolve({ data: { timestep: 5 } });
     }
     if (call === 2) {
-      return Promise.resolve(jsonResponse({ timestep: 6 }));
+      return Promise.resolve({ data: { timestep: 6 } });
     }
     return new Promise(() => {}); // pending long-poll
   });
-  vi.stubGlobal("fetch", fetchMock);
 
   const seen: number[] = [];
   const connected: boolean[] = [];
@@ -148,12 +141,12 @@ it("emits the current timestep first, then follows subsequent ones", async () =>
   controller.stop();
 
   expect(seen).toEqual([5, 6]);
-  expect(fetchMock).toHaveBeenNthCalledWith(
+  expect(getMock).toHaveBeenNthCalledWith(
     1,
     "https://h/d.zarr/current-timestep",
     expect.anything()
   );
-  expect(fetchMock).toHaveBeenNthCalledWith(
+  expect(getMock).toHaveBeenNthCalledWith(
     2,
     "https://h/d.zarr/next-timestep",
     expect.anything()
@@ -163,10 +156,7 @@ it("emits the current timestep first, then follows subsequent ones", async () =>
 });
 
 it("does not emit after stop() is called before start()", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue(jsonResponse({ timestep: 1 }))
-  );
+  vi.spyOn(axios, "get").mockResolvedValue({ data: { timestep: 1 } });
 
   const seen: number[] = [];
   const controller = new LiveTimestepController({

--- a/tests/unit/lib/data/liveTimestep.test.ts
+++ b/tests/unit/lib/data/liveTimestep.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import {
+  LiveTimestepController,
+  fetchCurrentTimestep,
+  fetchNextTimestep,
+  liveStoreBaseUrl,
+  timestepEndpointUrl,
+} from "@/lib/data/liveTimestep.ts";
+import { ZARR_FORMAT, type TSources } from "@/lib/types/GlobeTypes.ts";
+
+function makeSources(store: string): TSources {
+  return {
+    zarr_format: ZARR_FORMAT.V2, // eslint-disable-line camelcase
+    levels: [
+      {
+        time: { store, dataset: "" },
+        grid: { store, dataset: "" },
+        datasources: {},
+      },
+    ],
+  };
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+const signal = new AbortController().signal;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("joins the base URL and endpoint, normalizing trailing slashes", () => {
+  expect(timestepEndpointUrl("https://h/d.zarr", "current-timestep")).toBe(
+    "https://h/d.zarr/current-timestep"
+  );
+  expect(timestepEndpointUrl("https://h/d.zarr/", "next-timestep")).toBe(
+    "https://h/d.zarr/next-timestep"
+  );
+});
+
+it("resolves the normalized HTTP store URL for a fetch-backed dataset", () => {
+  expect(liveStoreBaseUrl(makeSources("https://h/d.zarr/"))).toBe(
+    "https://h/d.zarr"
+  );
+});
+
+it("returns undefined for an icechunk store (live mode is HTTP-only)", () => {
+  expect(
+    liveStoreBaseUrl(makeSources("icechunk+https://h/repo"))
+  ).toBeUndefined();
+});
+
+it("parses the timestep from the current-timestep endpoint", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ timestep: 7 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(fetchCurrentTimestep("https://h/d.zarr", signal)).resolves.toBe(
+    7
+  );
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://h/d.zarr/current-timestep",
+    expect.objectContaining({ signal })
+  );
+});
+
+it("accepts a numeric string in the timestep field", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(jsonResponse({ timestep: "42" }))
+  );
+  await expect(fetchCurrentTimestep("https://h/d.zarr", signal)).resolves.toBe(
+    42
+  );
+});
+
+it("long-polls the next-timestep endpoint", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ timestep: 8 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(fetchNextTimestep("https://h/d.zarr", signal)).resolves.toBe(8);
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://h/d.zarr/next-timestep",
+    expect.objectContaining({ signal })
+  );
+});
+
+it("throws on a non-OK response", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(jsonResponse({}, false, 503))
+  );
+  await expect(
+    fetchCurrentTimestep("https://h/d.zarr", signal)
+  ).rejects.toThrow(/HTTP 503/);
+});
+
+it("throws on an invalid payload", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(jsonResponse({ timestep: "nope" }))
+  );
+  await expect(
+    fetchCurrentTimestep("https://h/d.zarr", signal)
+  ).rejects.toThrow(/invalid payload/);
+});
+
+it("rejects negative or non-integer timesteps", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(jsonResponse({ timestep: -1 }))
+  );
+  await expect(
+    fetchCurrentTimestep("https://h/d.zarr", signal)
+  ).rejects.toThrow(/invalid payload/);
+});
+
+it("emits the current timestep first, then follows subsequent ones", async () => {
+  // current-timestep -> 5, next-timestep -> 6, then park (never resolves).
+  let call = 0;
+  const fetchMock = vi.fn().mockImplementation(() => {
+    call += 1;
+    if (call === 1) {
+      return Promise.resolve(jsonResponse({ timestep: 5 }));
+    }
+    if (call === 2) {
+      return Promise.resolve(jsonResponse({ timestep: 6 }));
+    }
+    return new Promise(() => {}); // pending long-poll
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const seen: number[] = [];
+  const connected: boolean[] = [];
+  const controller = new LiveTimestepController({
+    baseUrl: "https://h/d.zarr",
+    onTimestep: (t) => seen.push(t),
+    onConnectedChange: (c) => connected.push(c),
+  });
+  controller.start();
+  await flush();
+  await flush();
+  await flush();
+  controller.stop();
+
+  expect(seen).toEqual([5, 6]);
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    1,
+    "https://h/d.zarr/current-timestep",
+    expect.anything()
+  );
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    2,
+    "https://h/d.zarr/next-timestep",
+    expect.anything()
+  );
+  expect(connected).toContain(true);
+  expect(connected[connected.length - 1]).toBe(false); // stop() disconnects
+});
+
+it("does not emit after stop() is called before start()", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(jsonResponse({ timestep: 1 }))
+  );
+
+  const seen: number[] = [];
+  const controller = new LiveTimestepController({
+    baseUrl: "https://h/d.zarr",
+    onTimestep: (t) => seen.push(t),
+  });
+  controller.stop();
+  controller.start();
+  await flush();
+
+  expect(seen).toEqual([]);
+});


### PR DESCRIPTION
## feat: follow live datasets that stream one timestep at a time

### Summary

Adds support for **live datasets** — a Zarr store whose time axis is fully declared up front, but where only the currently-available timestep can be fetched at any moment. This lets Gridlook follow a running simulation or a rolling forecast, jumping to and re-rendering each new timestep as the model produces it.

Enable it by appending `::live=true` to the dataset URL:

```
https://gridlook.pages.dev/#<ZARR_URI>::live=true
```

### How it works

When live mode is active, Gridlook:

1. **Seeds** the initial time index from a `current-timestep` endpoint, so the very first render requests a chunk that actually exists (bounded by a 10s timeout; best-effort — the follow loop recovers on its own if it fails).
2. **Long-polls** a `next-timestep` endpoint and, whenever a newer timestep is reported, writes it into the time slider — which the existing grid loader already watches — triggering a refetch and re-render.
3. **Locks** the time slider (only one timestep is fetchable at a time) and swaps the playback controls for a **LIVE** badge with a pause/resume button. Pausing freezes the current frame; resuming jumps back to the newest timestep.
4. **Reconnects** with exponential backoff (1s → 30s cap) on network drops or `5xx`, showing a subtle "Reconnecting…" indicator until the connection recovers.

Live mode is HTTP-only (Zarr `FetchStore`); Icechunk stores are not supported. The live time index is deliberately kept out of the shareable URL, since it's re-seeded from the server on load.

### Server contract

The data server must expose two endpoints as siblings of the store root, each returning `{ "timestep": <index> }`:

| Endpoint | Behaviour |
| --- | --- |
| `current-timestep` | Responds immediately with the index available right now |
| `next-timestep` | Long-polls; responds only once a newer timestep is ready |

Full details in [`docs/live-datasets.md`](docs/live-datasets.md).

### Changes

- **New** `src/lib/data/liveTimestep.ts` — endpoint helpers plus `LiveTimestepController`, which drives the fetch-current-then-long-poll loop with backoff and abort handling.
- **New** `src/store/useLiveTimestep.ts` — Vue composable wiring the controller into the store, starting/stopping it as live/pause state and the datasource change.
- **Store** — new `live` / `livePaused` / `liveConnected` / `liveTimestep` state and actions; `live` URL param plumbed through `paramStore` and `urlParams`.
- **UI** — `DimensionControl.vue` shows the LIVE badge + pause/resume and disables manual time scrubbing; `useTimeAnimation.ts` disables playback for live datasets; `GlobeView.vue` seeds the initial timestep on load.
- **Tests** — `tests/unit/lib/data/liveTimestep.test.ts` covers URL joining, payload parsing/validation, HTTP-only detection, and the controller's emit-current-then-follow / stop-before-start behaviour.
- **Docs** — new `docs/live-datasets.md`; README pointer.

### Incidental: more robust HEALPix `nside` detection

`Healpix.vue`'s `getNside()` was refactored into a clear fallback chain — `healpix_nside` on the CRS variable → `dggs.refinement_level` on the group → inferring from a global grid's cell count (`ncells = 12 · nside²`) — with a descriptive error when none apply. This makes grid rendering more resilient for stores that don't carry an explicit `healpix_nside`.

### Notes

- `package-lock.json` churn is metadata only (`devOptional` → `dev` reclassification of platform-specific optional deps).
