### PR TITLE
fix(ui): resolve colormap swatches against the app base URL

### DIFF
--- a/src/ui/overlays/HoverReadout.vue
+++ b/src/ui/overlays/HoverReadout.vue
@@ -43,7 +43,7 @@ function loadColormapImage(name: string): Promise<void> {
       resolve();
     };
     img.onerror = () => resolve();
-    img.src = `/static/colormaps/${name}.webp`;
+    img.src = `${import.meta.env.BASE_URL}static/colormaps/${name}.webp`;
   });
 }
 

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -98,7 +98,7 @@ function handleBoundsHighUpdate(value: number) {
 // ---------------------------------------------------------------------------
 
 function swatchSrc(cm: TColorMap): string {
-  return `/static/colormaps/${cm}.webp`;
+  return `${import.meta.env.BASE_URL}static/colormaps/${cm}.webp`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The colormap gradient thumbnails in the colormap dropdown, and the gradient that HoverReadout samples to colour its swatch, were both requested from `/static/colormaps/<name>.webp`. The leading slash makes that an absolute, site-root URL, which ignores the `base` the app was built with.

vite.config.ts sets `base: "./"`, so gridlook is expected to work from whatever path it is deployed under. As soon as that is not the domain root — a GitHub Pages project site, or any subdirectory — every swatch request 404s against the root instead. Nothing reports it: ColormapControls renders a broken <img>, and HoverReadout's `img.onerror` resolves the promise, so the readout silently falls back to no swatch colour.

Prefixing both with `import.meta.env.BASE_URL` is what Vite provides for referencing files in `public/` from script: it is substituted with the configured `base` at build time, so the paths follow the app wherever it is mounted, and are unchanged when that is the domain root.