### PR TITLE
redesigned layer stack

### DIFF
--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -7,6 +7,10 @@
   --bulma-scheme-main-bis: hsl(0, 0%, 98%);
   --bulma-scheme-main-ter: hsl(0, 0%, 96%);
   --bulma-text: hsl(0, 0%, 29%);
+  --control-divider: color-mix(in srgb, var(--bulma-text) 12%, transparent);
+  --control-space-sm: 8px;
+  --control-space-md: 16px;
+  --control-space-lg: 24px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -99,50 +99,69 @@ export function normalizeLayerOpacity(opacity: number) {
   return opacity;
 }
 
-function builtinLayerStack(): TLayerEntry[] {
-  // ordered top → bottom, as displayed in the layer panel
-  return [
-    {
+export const BUILTIN_LAYER_NAMES = {
+  [LAYER_KINDS.COASTLINES]: "Coastlines",
+  [LAYER_KINDS.GRATICULES]: "Lat/Lon grid",
+  [LAYER_KINDS.GRID]: "Data grid",
+  [LAYER_KINDS.MASK]: "Land/sea mask",
+  [LAYER_KINDS.STREAMLINES]: "Flow streamlines",
+} as const satisfies Record<
+  Exclude<TLayerKind, typeof LAYER_KINDS.TEXTURE>,
+  string
+>;
+
+type TBuiltinLayerKind = keyof typeof BUILTIN_LAYER_NAMES;
+type TBuiltinLayerDefaults = Omit<TLayerEntry, "name" | "visible">;
+
+const BUILTIN_LAYER_DEFAULTS: Record<TBuiltinLayerKind, TBuiltinLayerDefaults> =
+  {
+    [LAYER_KINDS.COASTLINES]: {
+      id: BUILTIN_LAYER_IDS.COASTLINES,
+      kind: LAYER_KINDS.COASTLINES,
+      opacity: LAYER_OPACITY.MAX,
+      maskMode: LAND_SEA_MASK_MODES.OFF,
+    },
+    [LAYER_KINDS.GRATICULES]: {
+      id: BUILTIN_LAYER_IDS.GRATICULES,
+      kind: LAYER_KINDS.GRATICULES,
+      opacity: LAYER_OPACITY.MAX,
+      maskMode: LAND_SEA_MASK_MODES.OFF,
+    },
+    [LAYER_KINDS.GRID]: {
+      id: BUILTIN_LAYER_IDS.GRID,
+      kind: LAYER_KINDS.GRID,
+      opacity: LAYER_OPACITY.MAX,
+      maskMode: LAND_SEA_MASK_MODES.OFF,
+    },
+    [LAYER_KINDS.MASK]: {
+      id: BUILTIN_LAYER_IDS.MASK,
+      kind: LAYER_KINDS.MASK,
+      opacity: LAYER_OPACITY.MAX,
+      maskMode: LAND_SEA_MASK_MODES.OFF,
+    },
+    [LAYER_KINDS.STREAMLINES]: {
       id: BUILTIN_LAYER_IDS.STREAMLINES,
       kind: LAYER_KINDS.STREAMLINES,
-      name: "Flow streamlines",
-      visible: false,
       opacity: 0.55,
       maskMode: LAND_SEA_MASK_MODES.OFF,
     },
-    {
-      id: BUILTIN_LAYER_IDS.COASTLINES,
-      kind: LAYER_KINDS.COASTLINES,
-      name: "Coastlines",
-      visible: true,
-      opacity: LAYER_OPACITY.MAX,
-      maskMode: LAND_SEA_MASK_MODES.OFF,
-    },
-    {
-      id: BUILTIN_LAYER_IDS.GRATICULES,
-      kind: LAYER_KINDS.GRATICULES,
-      name: "Lat/Lon grid",
-      visible: false,
-      opacity: LAYER_OPACITY.MAX,
-      maskMode: LAND_SEA_MASK_MODES.OFF,
-    },
-    {
-      id: BUILTIN_LAYER_IDS.MASK,
-      kind: LAYER_KINDS.MASK,
-      name: "Land/sea mask",
-      visible: true,
-      opacity: LAYER_OPACITY.MAX,
-      maskMode: LAND_SEA_MASK_MODES.OFF,
-    },
-    {
-      id: BUILTIN_LAYER_IDS.GRID,
-      kind: LAYER_KINDS.GRID,
-      name: "Data grid",
-      visible: true,
-      opacity: LAYER_OPACITY.MAX,
-      maskMode: LAND_SEA_MASK_MODES.OFF,
-    },
-  ];
+  };
+
+const INITIAL_BUILTIN_LAYER_KINDS = [
+  LAYER_KINDS.COASTLINES,
+  LAYER_KINDS.GRID,
+] as const satisfies readonly TBuiltinLayerKind[];
+
+function createBuiltinLayer(kind: TBuiltinLayerKind): TLayerEntry {
+  return {
+    ...BUILTIN_LAYER_DEFAULTS[kind],
+    name: BUILTIN_LAYER_NAMES[kind],
+    visible: true,
+  };
+}
+
+function initialLayerStack(): TLayerEntry[] {
+  return INITIAL_BUILTIN_LAYER_KINDS.map(createBuiltinLayer);
 }
 
 export const useGlobeControlStore = defineStore("globeControl", {
@@ -192,7 +211,7 @@ export const useGlobeControlStore = defineStore("globeControl", {
       liveConnected: false, // whether the long-poll is currently connected
       liveTimestep: undefined as number | undefined, // latest known live index
       // layer panel stack, ordered top → bottom; order determines render order
-      layerStack: builtinLayerStack() as TLayerEntry[],
+      layerStack: initialLayerStack(),
       // incremented to request a GeoTIFF image-layer export of the current grid
       gridExportRequest: 0 as number,
       gridExportLoading: false,
@@ -345,8 +364,17 @@ export const useGlobeControlStore = defineStore("globeControl", {
         maskMode: LAND_SEA_MASK_MODES.OFF,
       });
     },
-    removeTextureLayer(id: string) {
+    removeLayer(id: string) {
       this.layerStack = this.layerStack.filter((layer) => layer.id !== id);
+    },
+    restoreBuiltinLayer(kind: TLayerKind) {
+      if (
+        kind === LAYER_KINDS.TEXTURE ||
+        this.layerStack.some((layer) => layer.kind === kind)
+      ) {
+        return;
+      }
+      this.layerStack.unshift(createBuiltinLayer(kind));
     },
     updateTextureLayer(
       id: string,
@@ -377,6 +405,9 @@ export const useGlobeControlStore = defineStore("globeControl", {
       );
     },
     setStreamlineLayerEnabled(enabled: boolean) {
+      if (enabled) {
+        this.restoreBuiltinLayer(LAYER_KINDS.STREAMLINES);
+      }
       const layer = this.layerStack.find(
         (entry) => entry.id === BUILTIN_LAYER_IDS.STREAMLINES
       );
@@ -393,22 +424,6 @@ export const useGlobeControlStore = defineStore("globeControl", {
       const [entry] = this.layerStack.splice(fromIndex, 1);
       const clamped = Math.max(0, Math.min(this.layerStack.length, toIndex));
       this.layerStack.splice(clamped, 0, entry);
-    },
-    /**
-     * Keep historic default behaviour: the globe mask sits below the grid,
-     * land/sea masks above. Called when the mask mode changes; the user can
-     * still re-drag the mask afterwards.
-     */
-    positionMaskLayerForMode(mode: TLandSeaMaskMode) {
-      const withoutMask = this.layerStack.filter(
-        (entry) => entry.kind !== LAYER_KINDS.MASK
-      );
-      const gridIndex = withoutMask.findIndex(
-        (entry) => entry.kind === LAYER_KINDS.GRID
-      );
-      const targetIndex =
-        mode === LAND_SEA_MASK_MODES.GLOBE ? gridIndex + 1 : gridIndex;
-      this.moveLayer(BUILTIN_LAYER_IDS.MASK, targetIndex);
     },
     requestGridExport() {
       this.gridExportRequest++;

--- a/src/ui/grids/composables/useGridOverlays.ts
+++ b/src/ui/grids/composables/useGridOverlays.ts
@@ -72,6 +72,16 @@ const GRATICULE_GEOJSON_PATHS: Record<TGraticuleSpacing, string> = {
   [GRATICULE_SPACINGS.THIRTY_DEGREES]: "static/ne_50m_graticules_30.geojson",
 };
 
+export function getLayerRenderOrder(
+  stack: readonly TLayerEntry[],
+  layerId: string
+) {
+  const gridIndex = stack.findIndex((entry) => entry.kind === LAYER_KINDS.GRID);
+  const layerIndex = stack.findIndex((entry) => entry.id === layerId);
+  const delta = gridIndex - layerIndex;
+  return delta > 0 ? 10 + delta : Math.max(delta, -9);
+}
+
 /* eslint-disable-next-line max-lines-per-function */
 export function useGridOverlays(options: UseGridOverlaysOptions) {
   const store = useGlobeControlStore();
@@ -262,6 +272,7 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
         scene.remove(coast);
       }
     } else {
+      store.restoreBuiltinLayer(LAYER_KINDS.COASTLINES);
       const lineSegments = await getCoastlines(updateId);
       if (
         !lineSegments ||
@@ -287,6 +298,7 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
         scene.remove(graticules);
       }
     } else {
+      store.restoreBuiltinLayer(LAYER_KINDS.GRATICULES);
       const lineSegments = await getGraticulesLayer(updateId);
       if (
         !lineSegments ||
@@ -316,6 +328,7 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
       return;
     }
 
+    store.restoreBuiltinLayer(LAYER_KINDS.MASK);
     const mask = await getLandSeaMask(
       landSeaMaskChoice.value!,
       landSeaMaskUseTexture.value!,
@@ -337,16 +350,12 @@ export function useGridOverlays(options: UseGridOverlaysOptions) {
    */
   function applyLayerOrders() {
     const stack = store.layerStack;
-    const gridIndex = stack.findIndex(
-      (entry) => entry.kind === LAYER_KINDS.GRID
-    );
-    for (const [index, entry] of stack.entries()) {
+    for (const entry of stack) {
       const layer = getLayerObject(entry);
       if (!layer) {
         continue;
       }
-      const delta = gridIndex - index;
-      const renderOrder = delta > 0 ? 10 + delta : Math.max(delta, -9);
+      const renderOrder = getLayerRenderOrder(stack, entry.id);
       if (layer instanceof THREE.Mesh) {
         applyLayerStackPosition(
           layer,

--- a/src/ui/grids/composables/useSharedGridLogic.ts
+++ b/src/ui/grids/composables/useSharedGridLogic.ts
@@ -18,7 +18,7 @@ import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import { availableColormaps } from "@/lib/shaders/colormapShaders.ts";
 import { getColormapScaleOffset } from "@/lib/shaders/gridShaders.ts";
 import type { TSources } from "@/lib/types/GlobeTypes.ts";
-import { useGlobeControlStore } from "@/store/store.ts";
+import { BUILTIN_LAYER_IDS, useGlobeControlStore } from "@/store/store.ts";
 import { useLog } from "@/ui/common/useLog.ts";
 
 type TVoidFunction = () => void;
@@ -128,15 +128,9 @@ export function useSharedGridLogic() {
   updateGraticules = updateGraticulesInternal;
   syncTextureLayersOnReady = () => updateTextureLayers();
 
-  // the mask mode may already be set from the URL before the grid mounts
-  store.positionMaskLayerForMode(landSeaMaskChoice.value);
-
   watch(
     [() => landSeaMaskChoice.value, () => landSeaMaskUseTexture.value],
-    ([newChoice], [oldChoice]) => {
-      if (newChoice !== oldChoice) {
-        store.positionMaskLayerForMode(newChoice);
-      }
+    () => {
       updateLandSeaMask();
     }
   );
@@ -146,6 +140,9 @@ export function useSharedGridLogic() {
     () => store.layerStack,
     () => {
       void updateTextureLayers();
+      for (const cb of colormapChangeCallbacks) {
+        cb();
+      }
     },
     { deep: true }
   );
@@ -217,11 +214,15 @@ export function useSharedGridLogic() {
       high,
       invertColormap.value
     );
+    const gridVisible =
+      store.layerStack.find((layer) => layer.id === BUILTIN_LAYER_IDS.GRID)
+        ?.visible ?? true;
 
     for (const myMesh of meshes) {
       if (!myMesh) {
         continue;
       }
+      myMesh.visible = gridVisible;
       const material = myMesh.material as THREE.ShaderMaterial;
       material.uniforms.colormap.value = availableColormaps[colormap.value];
       material.uniforms.addOffset.value = addOffset;

--- a/src/ui/grids/composables/useStreamlineLayer.ts
+++ b/src/ui/grids/composables/useStreamlineLayer.ts
@@ -1,6 +1,8 @@
 import type * as THREE from "three";
 import { onScopeDispose, watch, type ComputedRef } from "vue";
 
+import { getLayerRenderOrder } from "./useGridOverlays.ts";
+
 import type {
   TStreamlineVectorField,
   TVectorVariablePair,
@@ -29,17 +31,6 @@ function findLayerEntry(store: TStore) {
   return store.layerStack.find(
     (entry) => entry.id === BUILTIN_LAYER_IDS.STREAMLINES
   );
-}
-
-function getRenderOrder(store: TStore) {
-  const gridIndex = store.layerStack.findIndex(
-    (entry) => entry.id === BUILTIN_LAYER_IDS.GRID
-  );
-  const flowIndex = store.layerStack.findIndex(
-    (entry) => entry.id === BUILTIN_LAYER_IDS.STREAMLINES
-  );
-  const delta = gridIndex - flowIndex;
-  return delta > 0 ? 10 + delta : Math.max(delta, -9);
 }
 
 function syncAnimation(
@@ -72,7 +63,9 @@ export function useStreamlineLayer(options: TOptions) {
       return;
     }
     const entry = findLayerEntry(store);
-    layer.setRenderOrder(getRenderOrder(store));
+    layer.setRenderOrder(
+      getLayerRenderOrder(store.layerStack, BUILTIN_LAYER_IDS.STREAMLINES)
+    );
     layer.setOpacity(entry?.opacity ?? LAYER_OPACITY.MAX);
     const visible = Boolean(entry?.visible && store.streamlineAvailable);
     layer.object.visible = visible;

--- a/src/ui/overlays/controls/LayerPanel.vue
+++ b/src/ui/overlays/controls/LayerPanel.vue
@@ -1,8 +1,17 @@
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
-import { computed, onMounted, ref } from "vue";
-
-import PopupDialog from "./PopupDialog.vue";
+import { computed, nextTick, onMounted, ref } from "vue";
+import {
+  SelectListbox,
+  type SelectModelValue,
+  SelectOption,
+  SelectPopover,
+  SelectRoot,
+  SelectTrailingIcon,
+  SelectTrigger,
+  SelectValue,
+} from "vue3-select-component";
+import "vue3-select-component/styles.css";
 
 import { getVariableGroup } from "@/lib/data/vectorField.ts";
 import {
@@ -21,6 +30,7 @@ import {
 } from "@/lib/layers/textureStore.ts";
 import type { TModelInfo } from "@/lib/types/GlobeTypes.ts";
 import {
+  BUILTIN_LAYER_NAMES,
   COASTLINE_RESOLUTIONS,
   GRATICULE_SPACINGS,
   LAYER_KINDS,
@@ -54,7 +64,28 @@ const { logError } = useLog();
 const fileInput = ref<HTMLInputElement>();
 const draggedId = ref<string | undefined>(undefined);
 const dropTargetIndex = ref<number | undefined>(undefined);
+const expandedLayerId = ref<string | undefined>(undefined);
+const addLayerSelection = ref<TAddLayerAction | null>(null);
 const LAYER_ENTRY_SELECTOR = ".layer-entry";
+
+const ADD_LAYER_ACTIONS = {
+  COASTLINES: LAYER_KINDS.COASTLINES,
+  GRATICULES: LAYER_KINDS.GRATICULES,
+  MASK: LAYER_KINDS.MASK,
+  STREAMLINES: LAYER_KINDS.STREAMLINES,
+  UPLOAD: "upload",
+  VARIABLE_IMAGE: "variable-image",
+} as const;
+
+type TAddLayerAction =
+  (typeof ADD_LAYER_ACTIONS)[keyof typeof ADD_LAYER_ACTIONS];
+
+type TAddLayerOption = {
+  value: TAddLayerAction;
+  label: string;
+  icon: string;
+  disabled?: boolean;
+};
 
 const vectorVariables = computed(() =>
   Object.keys(props.modelInfo?.vars ?? {})
@@ -85,6 +116,18 @@ function setVectorComponent(component: "u" | "v", value: string) {
     [component]: value || undefined,
   });
 }
+
+const LAYER_BUTTONS = {
+  DOWNLOAD: "download",
+  OPACITY: "opacity",
+  REMOVE: "remove",
+} as const;
+
+type TLayerButton = (typeof LAYER_BUTTONS)[keyof typeof LAYER_BUTTONS];
+
+type TLayerProperties = {
+  buttons: TLayerButton[];
+};
 
 const LAYER_ICONS: Record<TLayerKind, string> = {
   [LAYER_KINDS.COASTLINES]: "fa-earth-europe",
@@ -179,6 +222,45 @@ const maskLayerOption = computed<TMaskLayerOption>({
   },
 });
 
+function toggleMaskLayerVisibility() {
+  if (landSeaMaskChoice.value === LAND_SEA_MASK_MODES.OFF) {
+    const config = MASK_LAYER_OPTION_CONFIG[lastVisibleMaskLayerOption.value];
+    landSeaMaskChoice.value = config.mode;
+    landSeaMaskUseTexture.value = config.useTexture;
+    return;
+  }
+  lastVisibleMaskLayerOption.value = getMaskLayerOption(
+    landSeaMaskChoice.value,
+    landSeaMaskUseTexture.value
+  );
+  landSeaMaskChoice.value = LAND_SEA_MASK_MODES.OFF;
+}
+
+const LAYER_PROPERTIES: Record<TLayerKind, TLayerProperties> = {
+  [LAYER_KINDS.COASTLINES]: {
+    buttons: [LAYER_BUTTONS.REMOVE],
+  },
+  [LAYER_KINDS.GRATICULES]: {
+    buttons: [LAYER_BUTTONS.REMOVE],
+  },
+  [LAYER_KINDS.GRID]: {
+    buttons: [],
+  },
+  [LAYER_KINDS.MASK]: {
+    buttons: [LAYER_BUTTONS.OPACITY, LAYER_BUTTONS.REMOVE],
+  },
+  [LAYER_KINDS.STREAMLINES]: {
+    buttons: [LAYER_BUTTONS.OPACITY, LAYER_BUTTONS.REMOVE],
+  },
+  [LAYER_KINDS.TEXTURE]: {
+    buttons: [
+      LAYER_BUTTONS.OPACITY,
+      LAYER_BUTTONS.DOWNLOAD,
+      LAYER_BUTTONS.REMOVE,
+    ],
+  },
+};
+
 onMounted(async () => {
   try {
     const stored = await loadTextures();
@@ -208,7 +290,14 @@ async function onFileSelected(event: Event) {
 }
 
 async function removeLayer(layer: TLayerEntry) {
-  store.removeTextureLayer(layer.id);
+  expandedLayerId.value = undefined;
+  if (layer.kind !== LAYER_KINDS.TEXTURE && isLayerVisible(layer)) {
+    toggleLayer(layer);
+  }
+  store.removeLayer(layer.id);
+  if (layer.kind !== LAYER_KINDS.TEXTURE) {
+    return;
+  }
   try {
     await deleteTexture(layer.id);
   } catch (error) {
@@ -253,7 +342,9 @@ function onDrop(index: number) {
 function isLayerControl(target: EventTarget | null) {
   return (
     target instanceof Element &&
-    Boolean(target.closest(".layer-actions, .streamline-components"))
+    Boolean(
+      target.closest(".layer-actions, .layer-details, .streamline-components")
+    )
   );
 }
 
@@ -320,8 +411,114 @@ function isLayerAvailable(layer: TLayerEntry) {
   return layer.kind !== LAYER_KINDS.STREAMLINES || Boolean(props.modelInfo);
 }
 
-function canToggleLayer(layer: TLayerEntry) {
-  return layer.kind !== LAYER_KINDS.STREAMLINES || Boolean(props.modelInfo);
+const displayedLayerStack = computed(() =>
+  layerStack.value.filter(isLayerAvailable)
+);
+
+function hasDisplayedLayer(kind: TLayerKind) {
+  return displayedLayerStack.value.some((layer) => layer.kind === kind);
+}
+
+const addLayerOptions = computed<TAddLayerOption[]>(() => {
+  const options: TAddLayerOption[] = [];
+  if (!hasDisplayedLayer(LAYER_KINDS.COASTLINES)) {
+    options.push({
+      value: ADD_LAYER_ACTIONS.COASTLINES,
+      label: BUILTIN_LAYER_NAMES[LAYER_KINDS.COASTLINES],
+      icon: LAYER_ICONS[LAYER_KINDS.COASTLINES],
+    });
+  }
+  if (!hasDisplayedLayer(LAYER_KINDS.GRATICULES)) {
+    options.push({
+      value: ADD_LAYER_ACTIONS.GRATICULES,
+      label: BUILTIN_LAYER_NAMES[LAYER_KINDS.GRATICULES],
+      icon: LAYER_ICONS[LAYER_KINDS.GRATICULES],
+    });
+  }
+  if (!hasDisplayedLayer(LAYER_KINDS.MASK)) {
+    options.push({
+      value: ADD_LAYER_ACTIONS.MASK,
+      label: BUILTIN_LAYER_NAMES[LAYER_KINDS.MASK],
+      icon: LAYER_ICONS[LAYER_KINDS.MASK],
+    });
+  }
+  if (!hasDisplayedLayer(LAYER_KINDS.STREAMLINES)) {
+    options.push({
+      value: ADD_LAYER_ACTIONS.STREAMLINES,
+      label: BUILTIN_LAYER_NAMES[LAYER_KINDS.STREAMLINES],
+      icon: LAYER_ICONS[LAYER_KINDS.STREAMLINES],
+      disabled: !props.modelInfo,
+    });
+  }
+  options.push(
+    {
+      value: ADD_LAYER_ACTIONS.UPLOAD,
+      label: "Upload image layer",
+      icon: "fa-upload",
+    },
+    {
+      value: ADD_LAYER_ACTIONS.VARIABLE_IMAGE,
+      label:
+        varnameDisplay.value === "-"
+          ? "Current variable as image layer"
+          : `"${varnameDisplay.value}" as image layer`,
+      icon: "fa-camera",
+      disabled: store.gridExportLoading || varnameDisplay.value === "-",
+    }
+  );
+  return options;
+});
+
+function addLayer(action: TAddLayerAction) {
+  if (action === ADD_LAYER_ACTIONS.COASTLINES) {
+    store.restoreBuiltinLayer(LAYER_KINDS.COASTLINES);
+    if (!showCoastLines.value) {
+      store.toggleCoastLines();
+    }
+  } else if (action === ADD_LAYER_ACTIONS.GRATICULES) {
+    store.restoreBuiltinLayer(LAYER_KINDS.GRATICULES);
+    if (!showGraticules.value) {
+      store.toggleGraticules();
+    }
+  } else if (action === ADD_LAYER_ACTIONS.MASK) {
+    store.restoreBuiltinLayer(LAYER_KINDS.MASK);
+    if (landSeaMaskChoice.value === LAND_SEA_MASK_MODES.OFF) {
+      const config = MASK_LAYER_OPTION_CONFIG[lastVisibleMaskLayerOption.value];
+      landSeaMaskChoice.value = config.mode;
+      landSeaMaskUseTexture.value = config.useTexture;
+    }
+  } else if (action === ADD_LAYER_ACTIONS.STREAMLINES) {
+    store.restoreBuiltinLayer(LAYER_KINDS.STREAMLINES);
+    store.setStreamlineLayerEnabled(true);
+  } else if (action === ADD_LAYER_ACTIONS.UPLOAD) {
+    fileInput.value?.click();
+  } else if (
+    action === ADD_LAYER_ACTIONS.VARIABLE_IMAGE &&
+    !store.gridExportLoading &&
+    varnameDisplay.value !== "-"
+  ) {
+    store.requestGridExport();
+  }
+}
+
+function onAddLayerSelection(value: SelectModelValue<TAddLayerAction>) {
+  if (value === null || Array.isArray(value)) {
+    return;
+  }
+  addLayerSelection.value = value;
+  addLayer(value);
+  void nextTick(() => {
+    addLayerSelection.value = null;
+  });
+}
+
+function getLayerStackIndex(layer: TLayerEntry) {
+  return layerStack.value.indexOf(layer);
+}
+
+function toggleExpandedLayer(layer: TLayerEntry) {
+  expandedLayerId.value =
+    expandedLayerId.value === layer.id ? undefined : layer.id;
 }
 
 function toggleLayer(layer: TLayerEntry) {
@@ -330,30 +527,12 @@ function toggleLayer(layer: TLayerEntry) {
   } else if (layer.kind === LAYER_KINDS.GRATICULES) {
     store.toggleGraticules();
   } else if (layer.kind === LAYER_KINDS.MASK) {
-    if (landSeaMaskChoice.value === LAND_SEA_MASK_MODES.OFF) {
-      const config = MASK_LAYER_OPTION_CONFIG[lastVisibleMaskLayerOption.value];
-      landSeaMaskChoice.value = config.mode;
-      landSeaMaskUseTexture.value = config.useTexture;
-    } else {
-      lastVisibleMaskLayerOption.value = getMaskLayerOption(
-        landSeaMaskChoice.value,
-        landSeaMaskUseTexture.value
-      );
-      landSeaMaskChoice.value = LAND_SEA_MASK_MODES.OFF;
-    }
+    toggleMaskLayerVisibility();
   } else if (layer.kind === LAYER_KINDS.TEXTURE) {
     store.updateTextureLayer(layer.id, { visible: !layer.visible });
-  } else if (layer.kind === LAYER_KINDS.STREAMLINES) {
+  } else {
     store.toggleLayerVisibility(layer.id);
   }
-}
-
-function canChangeLayerOpacity(layer: TLayerEntry) {
-  return (
-    layer.kind === LAYER_KINDS.MASK ||
-    layer.kind === LAYER_KINDS.STREAMLINES ||
-    layer.kind === LAYER_KINDS.TEXTURE
-  );
 }
 
 function getLayerOpacity(layer: TLayerEntry) {
@@ -375,9 +554,6 @@ function getLayerName(layer: TLayerEntry) {
   if (layer.kind === LAYER_KINDS.GRID && varnameDisplay.value !== "-") {
     return `${layer.name}: ${varnameDisplay.value}`;
   }
-  if (layer.kind === LAYER_KINDS.STREAMLINES) {
-    return "Streamlines integrated by RK4/3";
-  }
   return layer.name;
 }
 </script>
@@ -386,37 +562,37 @@ function getLayerName(layer: TLayerEntry) {
   <div class="column">
     <ul class="layer-stack mb-2">
       <li
-        v-for="(layer, index) in layerStack"
-        v-show="isLayerAvailable(layer)"
+        v-for="layer in displayedLayerStack"
         :key="layer.id"
         class="layer-entry"
         :class="{
           'is-inactive': !isLayerVisible(layer),
-          'is-drop-target': dropTargetIndex === index,
+          'is-drop-target': dropTargetIndex === getLayerStackIndex(layer),
           'is-dragging': draggedId === layer.id,
         }"
-        :data-layer-index="index"
-        draggable="true"
+        :data-layer-index="getLayerStackIndex(layer)"
         @dragstart="onDragStart($event, layer)"
-        @dragover="onDragOver($event, index)"
-        @drop="onDrop(index)"
+        @dragover="onDragOver($event, getLayerStackIndex(layer))"
+        @drop="onDrop(getLayerStackIndex(layer))"
         @dragend="endDrag"
-        @touchstart="onTouchStart($event, layer, index)"
+        @touchstart="onTouchStart($event, layer, getLayerStackIndex(layer))"
         @touchmove="onTouchMove"
         @touchend="onTouchEnd"
         @touchcancel="endDrag"
       >
-        <span class="icon is-small">
-          <i class="fa-solid" :class="LAYER_ICONS[layer.kind]"></i>
-        </span>
-        <span class="layer-name is-size-7" :title="getLayerName(layer)">
-          {{ layer.name }}
-          <template
-            v-if="layer.kind === LAYER_KINDS.GRID && varnameDisplay !== '-'"
-          >
-            : <strong class="is-family-code">{{ varnameDisplay }}</strong>
-          </template>
-        </span>
+        <div class="layer-drag-handle" draggable="true">
+          <span class="icon is-small">
+            <i class="fa-solid" :class="LAYER_ICONS[layer.kind]"></i>
+          </span>
+          <span class="layer-name is-size-7" :title="getLayerName(layer)">
+            {{ layer.name }}
+            <template
+              v-if="layer.kind === LAYER_KINDS.GRID && varnameDisplay !== '-'"
+            >
+              : <strong class="is-family-code">{{ varnameDisplay }}</strong>
+            </template>
+          </span>
+        </div>
         <div class="layer-actions">
           <template v-if="layer.kind === LAYER_KINDS.COASTLINES">
             <div class="select is-small layer-select">
@@ -443,7 +619,7 @@ function getLayerName(layer: TLayerEntry) {
               <select
                 id="land_sea_mask"
                 v-model="maskLayerOption"
-                title="Land/sea mask"
+                :title="BUILTIN_LAYER_NAMES[LAYER_KINDS.MASK]"
               >
                 <option :value="MASK_LAYER_OPTIONS.GLOBE">Globe</option>
                 <option :value="MASK_LAYER_OPTIONS.GLOBE_SIMPLE">
@@ -477,7 +653,94 @@ function getLayerName(layer: TLayerEntry) {
                 <option :value="LAND_SEA_MASK_MODES.SEA">Sea</option>
               </select>
             </div>
+          </template>
+          <template v-if="layer.kind === LAYER_KINDS.GRID">
+            <span
+              class="tag is-info"
+              :class="{ 'is-light': !store.hoverEnabled }"
+              >Active data</span
+            >
+          </template>
+          <button
+            v-if="LAYER_PROPERTIES[layer.kind].buttons.length >= 1"
+            class="button is-small is-light layer-expand-button"
+            type="button"
+            title="More layer controls"
+            :aria-expanded="expandedLayerId === layer.id"
+            :aria-label="`More controls for ${layer.name}`"
+            @click="toggleExpandedLayer(layer)"
+          >
+            <span class="icon is-small">
+              <i class="fa-solid fa-ellipsis"></i>
+            </span>
+          </button>
+          <button
+            class="button is-small is-light"
+            :class="{ 'is-info': isLayerVisible(layer) }"
+            type="button"
+            :disabled="layer.kind === LAYER_KINDS.STREAMLINES && !modelInfo"
+            :title="isLayerVisible(layer) ? 'Hide layer' : 'Show layer'"
+            :aria-pressed="isLayerVisible(layer)"
+            @click="toggleLayer(layer)"
+          >
+            <span class="icon is-small">
+              <i
+                class="fa-solid"
+                :class="isLayerVisible(layer) ? 'fa-eye' : 'fa-eye-slash'"
+              ></i>
+            </span>
+          </button>
+        </div>
+        <div v-if="expandedLayerId === layer.id" class="layer-details">
+          <label
+            v-if="
+              LAYER_PROPERTIES[layer.kind].buttons.includes(
+                LAYER_BUTTONS.OPACITY
+              )
+            "
+            class="layer-opacity-control"
+          >
+            <span class="layer-opacity-header">
+              <span>Opacity</span>
+              <span class="tag is-light layer-opacity-value">
+                {{ formatLayerOpacity(layer) }}
+              </span>
+            </span>
+            <input
+              class="layer-opacity"
+              type="range"
+              :min="LAYER_OPACITY.MIN"
+              :max="LAYER_OPACITY.MAX"
+              :step="LAYER_OPACITY.STEP"
+              :value="getLayerOpacity(layer)"
+              :aria-label="`${layer.name} opacity`"
+              @input="setLayerOpacity(layer, $event)"
+            />
+          </label>
+          <div
+            v-if="
+              LAYER_PROPERTIES[layer.kind].buttons.includes(
+                LAYER_BUTTONS.REMOVE
+              ) ||
+              LAYER_PROPERTIES[layer.kind].buttons.includes(
+                LAYER_BUTTONS.DOWNLOAD
+              )
+            "
+            class="layer-detail-actions"
+            :class="
+              LAYER_PROPERTIES[layer.kind].buttons.includes(
+                LAYER_BUTTONS.OPACITY
+              )
+                ? 'layer-detail-actions-margin'
+                : ''
+            "
+          >
             <button
+              v-if="
+                LAYER_PROPERTIES[layer.kind].buttons.includes(
+                  LAYER_BUTTONS.DOWNLOAD
+                )
+              "
               class="button is-small is-light"
               type="button"
               title="Download layer"
@@ -486,88 +749,26 @@ function getLayerName(layer: TLayerEntry) {
               <span class="icon is-small">
                 <i class="fa-solid fa-download"></i>
               </span>
+              <span>Download Layer</span>
             </button>
             <button
-              class="button is-small is-light"
+              v-if="
+                LAYER_PROPERTIES[layer.kind].buttons.includes(
+                  LAYER_BUTTONS.REMOVE
+                )
+              "
+              class="button is-small is-danger"
               type="button"
-              title="Delete layer"
+              title="Remove layer"
+              :aria-label="`Remove ${layer.name}`"
               @click="removeLayer(layer)"
             >
               <span class="icon is-small">
                 <i class="fa-solid fa-trash"></i>
               </span>
+              <span>Remove Layer</span>
             </button>
-          </template>
-          <template v-if="canChangeLayerOpacity(layer)">
-            <PopupDialog dialog-class="layer-opacity-popover">
-              <template #trigger="{ toggle, open }">
-                <button
-                  class="button is-small is-light"
-                  :class="{
-                    'is-info':
-                      open || getLayerOpacity(layer) < LAYER_OPACITY.MAX,
-                  }"
-                  type="button"
-                  :title="`Opacity: ${formatLayerOpacity(layer)}`"
-                  :aria-expanded="open"
-                  :aria-label="`${layer.name} opacity`"
-                  @click.stop="toggle"
-                  @mousedown.stop
-                  @touchstart.stop
-                >
-                  <span class="icon is-small">
-                    <i class="fa-solid fa-circle-half-stroke"></i>
-                  </span>
-                </button>
-              </template>
-
-              <template #default>
-                <label class="layer-opacity-control">
-                  <span class="layer-opacity-header">
-                    <span>Opacity</span>
-                    <span class="tag is-light layer-opacity-value">
-                      {{ formatLayerOpacity(layer) }}
-                    </span>
-                  </span>
-                  <input
-                    class="layer-opacity"
-                    type="range"
-                    :min="LAYER_OPACITY.MIN"
-                    :max="LAYER_OPACITY.MAX"
-                    :step="LAYER_OPACITY.STEP"
-                    :value="getLayerOpacity(layer)"
-                    :aria-label="`${layer.name} opacity`"
-                    @input="setLayerOpacity(layer, $event)"
-                  />
-                </label>
-              </template>
-            </PopupDialog>
-          </template>
-          <template v-else-if="layer.kind === LAYER_KINDS.GRID">
-            <span
-              class="tag is-info"
-              :class="{ 'is-light': !store.hoverEnabled }"
-              >Active data</span
-            >
-          </template>
-          <template v-if="layer.kind !== LAYER_KINDS.GRID">
-            <button
-              class="button is-small is-light"
-              :class="{ 'is-info': isLayerVisible(layer) }"
-              type="button"
-              :disabled="!canToggleLayer(layer)"
-              :title="isLayerVisible(layer) ? 'Hide layer' : 'Show layer'"
-              :aria-pressed="isLayerVisible(layer)"
-              @click="toggleLayer(layer)"
-            >
-              <span class="icon is-small">
-                <i
-                  class="fa-solid"
-                  :class="isLayerVisible(layer) ? 'fa-eye' : 'fa-eye-slash'"
-                ></i>
-              </span>
-            </button>
-          </template>
+          </div>
         </div>
         <div
           v-if="layer.kind === LAYER_KINDS.STREAMLINES && isLayerVisible(layer)"
@@ -624,45 +825,54 @@ function getLayerName(layer: TLayerEntry) {
         </div>
       </li>
     </ul>
-    <div class="buttons">
-      <button
-        class="button is-small is-light"
-        type="button"
-        title="Upload a texture image (PNG, JPG, or GeoTIFF)"
-        @click="fileInput?.click()"
-      >
-        <span class="icon is-small"><i class="fa-solid fa-upload"></i></span>
-        <span>Upload</span>
-      </button>
-      <button
-        class="button is-small is-light"
-        :class="{ 'is-loading': store.gridExportLoading }"
-        type="button"
-        :disabled="store.gridExportLoading || varnameDisplay === '-'"
-        title="Export the current grid as a GeoTIFF texture layer"
-        @click="store.requestGridExport()"
-      >
-        <span class="icon is-small"><i class="fa-solid fa-camera"></i></span>
-        <span>
-          <span class="is-family-code is-danger">"{{ varnameDisplay }}"</span>
-          as image layer</span
-        >
-      </button>
-      <input
-        ref="fileInput"
-        :accept="TEXTURE_LAYER_UPLOAD_ACCEPT"
-        class="is-hidden"
-        type="file"
-        @change="onFileSelected"
-      />
-    </div>
+    <SelectRoot
+      :model-value="addLayerSelection"
+      :options="addLayerOptions"
+      :loading="store.gridExportLoading"
+      class="add-layer-select"
+      data-assembled-select
+      @update:model-value="onAddLayerSelection"
+    >
+      <SelectTrigger aria-label="Add layer">
+        <SelectValue placeholder="Add layer…" />
+        <SelectTrailingIcon>
+          <i class="fa-solid fa-angle-down is-size-5"></i>
+        </SelectTrailingIcon>
+      </SelectTrigger>
+
+      <SelectPopover>
+        <SelectListbox>
+          <SelectOption
+            v-for="option in addLayerOptions"
+            :key="option.value"
+            :value="option.value"
+            :label="option.label"
+            :disabled="option.disabled"
+          >
+            <span class="add-layer-option">
+              <span class="icon is-small">
+                <i class="fa-solid" :class="option.icon"></i>
+              </span>
+              <span>{{ option.label }}</span>
+            </span>
+          </SelectOption>
+        </SelectListbox>
+      </SelectPopover>
+    </SelectRoot>
+    <input
+      ref="fileInput"
+      :accept="TEXTURE_LAYER_UPLOAD_ACCEPT"
+      class="is-hidden"
+      type="file"
+      @change="onFileSelected"
+    />
   </div>
 </template>
 
 <style lang="scss" scoped>
 .layer-stack {
-  border: 1px solid var(--bulma-border);
   border-radius: 4px;
+  background: var(--bulma-scheme-main-bis);
 }
 
 .layer-entry {
@@ -670,12 +880,10 @@ function getLayerName(layer: TLayerEntry) {
   align-items: center;
   gap: 0.4rem;
   padding: 0.3rem 0.5rem;
-  cursor: grab;
-  touch-action: none;
   flex-wrap: wrap;
 
   &:not(:last-child) {
-    border-bottom: 1px solid var(--bulma-border);
+    border-bottom: 1px solid var(--control-divider);
   }
 
   &.is-dragging {
@@ -695,6 +903,17 @@ function getLayerName(layer: TLayerEntry) {
   &.is-drop-target {
     outline: 2px solid var(--bulma-link);
   }
+}
+
+.layer-drag-handle {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  flex: 1;
+  gap: 0.4rem;
+  min-width: 4rem;
+  cursor: grab;
+  touch-action: none;
 }
 
 .streamline-components {
@@ -733,13 +952,33 @@ function getLayerName(layer: TLayerEntry) {
   gap: 0.35rem;
 }
 
+.layer-expand-button {
+  min-width: 2rem;
+  font-weight: 700;
+}
+
+.layer-details {
+  flex-basis: 100%;
+  // padding: 0 1.65rem;
+}
+
+.layer-detail-actions-margin {
+  margin-top: 0.5rem;
+}
+
+.layer-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
 .layer-select select {
   max-width: 7rem;
 }
 
 .layer-opacity-control {
   display: block;
-  min-width: 11rem;
+  width: 100%;
 }
 
 .layer-opacity-header {
@@ -759,5 +998,52 @@ function getLayerName(layer: TLayerEntry) {
 .layer-opacity-value {
   min-width: 2.5rem;
   justify-content: center;
+}
+
+.add-layer-select {
+  width: 100%;
+  font-size: 1rem;
+  font-family: inherit;
+  --vs-min-height: 2rem;
+  --vs-padding-y: 0;
+  --vs-padding-x: 0.625em;
+  --vs-border: 1px solid var(--bulma-border, #dbdbdb);
+  --vs-border-radius: 4px;
+  --vs-background-color: var(--bulma-scheme-main, #fff);
+  --vs-text-color: var(--bulma-text, #363636);
+  --vs-outline-color: rgb(66, 88, 255);
+  --vs-outline-width: 3px;
+  --vs-trailing-icon-color: var(--bulma-link);
+}
+
+:deep([data-select-trigger][aria-expanded="true"]),
+:deep([data-select-trigger]:focus-visible) {
+  box-shadow: rgba(66, 88, 255, 0.25) 0 0 0 3px;
+}
+
+:deep([data-select-value]) {
+  line-height: 1;
+  height: 100%;
+}
+
+:deep([data-select-trailing-icon][data-loading="true"] i) {
+  display: none;
+}
+
+.add-layer-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  min-width: 0;
+}
+
+:global([data-select-popover]) {
+  --vs-border: 1px solid var(--bulma-border, #dbdbdb);
+  --vs-border-radius: 4px;
+  --vs-menu-background-color: var(--bulma-scheme-main, #fff);
+  --vs-menu-z-index: 1000;
+  --vs-option-hover-background-color: var(--bulma-scheme-main-bis, #fafafa);
+  --vs-option-focused-background-color: var(--bulma-scheme-main-ter, #f5f5f5);
+  --vs-option-selected-background-color: var(--bulma-info-soft, #eef6fc);
 }
 </style>

--- a/tests/unit/store/store.test.ts
+++ b/tests/unit/store/store.test.ts
@@ -8,15 +8,30 @@ vi.stubGlobal("localStorage", {
 });
 
 const { createPinia, setActivePinia } = await import("pinia");
-const { BUILTIN_LAYER_IDS, LAYER_OPACITY, useGlobeControlStore } =
-  await import("@/store/store.ts");
+const {
+  BUILTIN_LAYER_IDS,
+  BUILTIN_LAYER_NAMES,
+  LAYER_KINDS,
+  LAYER_OPACITY,
+  useGlobeControlStore,
+} = await import("@/store/store.ts");
 
 beforeEach(() => {
   setActivePinia(createPinia());
 });
 
+it("starts with only coastlines and the active data grid", () => {
+  const store = useGlobeControlStore();
+
+  expect(store.layerStack.map((layer) => layer.id)).toEqual([
+    BUILTIN_LAYER_IDS.COASTLINES,
+    BUILTIN_LAYER_IDS.GRID,
+  ]);
+});
+
 it("defaults layer opacity to opaque and clamps updates", () => {
   const store = useGlobeControlStore();
+  store.restoreBuiltinLayer(LAYER_KINDS.MASK);
   const maskLayer = store.layerStack.find(
     (layer) => layer.id === BUILTIN_LAYER_IDS.MASK
   );
@@ -50,4 +65,37 @@ it("sets streamline layer visibility explicitly", () => {
   expect(store.isStreamlineLayerEnabled()).toBe(true);
   store.setStreamlineLayerEnabled(false);
   expect(store.isStreamlineLayerEnabled()).toBe(false);
+});
+
+it("stores active data layer visibility and opacity", () => {
+  const store = useGlobeControlStore();
+  const gridLayer = store.layerStack.find(
+    (layer) => layer.id === BUILTIN_LAYER_IDS.GRID
+  );
+
+  expect(gridLayer?.visible).toBe(true);
+  store.toggleLayerVisibility(BUILTIN_LAYER_IDS.GRID);
+  store.updateLayerOpacity(BUILTIN_LAYER_IDS.GRID, 0.4);
+
+  expect(gridLayer?.visible).toBe(false);
+  expect(gridLayer?.opacity).toBe(0.4);
+});
+
+it("removes and restores built-in layers", () => {
+  const store = useGlobeControlStore();
+
+  expect(
+    store.layerStack.some((layer) => layer.id === BUILTIN_LAYER_IDS.MASK)
+  ).toBe(false);
+
+  store.restoreBuiltinLayer(LAYER_KINDS.MASK);
+  expect(store.layerStack[0]?.id).toBe(BUILTIN_LAYER_IDS.MASK);
+  expect(store.layerStack[0]?.name).toBe(BUILTIN_LAYER_NAMES[LAYER_KINDS.MASK]);
+  expect(store.layerStack[0]?.visible).toBe(true);
+  expect(store.layerStack[0]?.opacity).toBe(LAYER_OPACITY.MAX);
+
+  store.restoreBuiltinLayer(LAYER_KINDS.MASK);
+  expect(
+    store.layerStack.filter((layer) => layer.id === BUILTIN_LAYER_IDS.MASK)
+  ).toHaveLength(1);
 });


### PR DESCRIPTION
Redesigned the Layer Stack. All layers except for the Data Layer and Coastlines are now hidden in a dropdown. The Data Layer can be hidden now, as well. All the additional buttons except for the visibility button and any possible dropdowns are now hidden via an "..."-Button.

Also the "Land/Sea-Mask"-Layer no longer changes the position when changing the Mask-Type.

It is still not possible to set the opacity of the Data Layer, but I have not forgotten about it. I didn't implement it as this would again require touching of all the Grid Files which I don't want right now. I think at some point I need a registry for stuff like that so that I can register functionality like this in a registry, so that we don't have to touch dozens of files every time a feature requires touching all of the files..