### PR TITLE
Knip and faster metadata loading

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Run linter
         run: npm run lint-ci
 
+      - name: Run knip
+        run: npm run knip
+
       - name: Run type checker
         run: npm run typecheck
 

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": ["bulma"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
+        "@eslint/js": "^9.39.4",
         "@types/d3-delaunay": "^6.0.4",
         "@types/d3-geo": "^3.1.1",
         "@types/geojson": "7946.0.16",
@@ -63,6 +64,7 @@
         "eslint-plugin-vue": "10.9",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
+        "knip": "6.34.0",
         "lint-staged": "^17.0.7",
         "prettier": "^3.8.4",
         "sass": "~1.89.2",
@@ -572,21 +574,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -595,9 +597,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -987,6 +989,353 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.147.0.tgz",
+      "integrity": "sha512-fOtoGvIoirkvxQVw9J1WJPxz571XPgLsPf9uhRD+PJteUnvrJHMDmK9pw2yZEGGyismtRoEsp+JcXUdF/JDMDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.147.0.tgz",
+      "integrity": "sha512-emjQHOYJaomo4ykaXQ1EItunr/I94Nk01oqBmU4dSkKSTupIDx6OysVDf2e8Eytm77rb+4ZxzgElyWP7rcEX7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.147.0.tgz",
+      "integrity": "sha512-kXvBPJL7RmDPJ2mze/vXPPVQimCDtFr9OFLjf7dyhV5Dx64cgcXh9KKrA1sMWvCObvJll9CZZUO0FBlFwD0l6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.147.0.tgz",
+      "integrity": "sha512-mgFF8pLU6R64LbT27lSrtVRspVC/3IcZ0qyIikzmi78Y3Ik2OPnlAHHI0UEBRcC3qmNgtjaef7zkFt7/uPxIcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.147.0.tgz",
+      "integrity": "sha512-v38aiF11qufOTBcCAKL4skgQf0zJ4NEvRlivq7B5kHrlyvjCLjvNrMtNWDTz1SDUL6/xVsJRmLDxv2e+Cp4oWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.147.0.tgz",
+      "integrity": "sha512-AeIiBbwUaP0H1+4/qGW9l5qHecS/+XA5iMuieVcGb1T+tyc2dVGspFW13BWk/XrLsiGP/CiDJTJqAPLLCzZHkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.147.0.tgz",
+      "integrity": "sha512-/41MKPW4RgPY4DJco0NCF0RYX3IMZaVlRNMNzvhaxRavc7tN3Txm+qllZbh0aMRs0VHdgUlbI8TcAOiTai4TKg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.147.0.tgz",
+      "integrity": "sha512-bmpw/RPhVXgZbtb3xBDuwW5s8+LvZYdqcDSX/sP2ltL77aTio3DP/B5ZTwwgoJ6Mr9vJs4RrmgEKW9XkLNUU1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.147.0.tgz",
+      "integrity": "sha512-gd7VX/FDVOw6mjQcu45iIcp4QkgybgJwh3a0OFG2NxmPCj628mQWD96QGu1kK8+mZF9qK4b/gIEyC63vQoB7+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.147.0.tgz",
+      "integrity": "sha512-HnAzcfki7dSUNHf510Q2NmbJlz8Ys7rn8l9l588Pkx0tYe1BHLZnmELIgqizJ4WPhHGSwN8Ce+B/menVxS3odA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.147.0.tgz",
+      "integrity": "sha512-qlkOL6wT44U+fT5s/+sR6Shx0OdwvQF83JyIPZUxG/ovqZF5/7atOtjH+JPZ5/7ATQLbFBBSmghcy/+2NVB/ew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.147.0.tgz",
+      "integrity": "sha512-DlefD7L7sMXs/3hIBH23Egk0phj8kG0SA81dVGOQ3S1ekjOlmTLH2E+F2Thwfh1slKx6aH+lNc5fQYAw0GU7/g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.147.0.tgz",
+      "integrity": "sha512-Xqpagk/031IvZ4svrk2FF01YEqM/iN3MJV3SVZadKg/CsGlDCGoREqKHXYnoV5+8SfGe/m6RM1szXFLusTu/Uw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.147.0.tgz",
+      "integrity": "sha512-QioQOeUbI4ATUr0S2z88uA3Cds2R3Mm5Ge7U8XNYtlTb2GJF3rWlcj70z0AJhhOlbdm0YgVjqPBldUNbFylDIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.147.0.tgz",
+      "integrity": "sha512-NXy1tv/OdC+pPTwf9RiCZWPK53V/Xq/2cjSnjOSyKopajdaDqMIkgtDY+jXZemp2e8px5FeWfY2L2LwhKZQovg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.147.0.tgz",
+      "integrity": "sha512-GpGWZ6oKz4bjCWW9Mz5pCaGPyk2Aaze6zEoaslIQqpSLtpx5pXj/ap5gUNb5Jn2LIbqWyjkGLX9yv3NMuNcBVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.147.0.tgz",
+      "integrity": "sha512-a8mlt7CC8z7LUdCfaxhff4kCd+vSjE+NEFL0cxA8ukfuSnvAto/pWTjytW4BuVLnQGcCVdHJwcRKOfs++H+tjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.147.0.tgz",
+      "integrity": "sha512-M5ViVDBcFLnl2632AuuWuP35zEL5oikK1jTx8r3+902VEDeSNHxFZAB6RZyfZ7MU6Oi5QTOG8MmMkIeHsudSaw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.147.0.tgz",
+      "integrity": "sha512-DUaE13OwnUSlHpLZNcC/nuT10ivlWqc5EZgsfgXuAmWYw0r3nDxGeLD1zlGwYwIgVk1/ZMAxoXpV+05stvbHaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.143.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
@@ -996,6 +1345,323 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
@@ -1643,9 +2309,9 @@
       "dev": true
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4586,6 +5252,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
@@ -4708,6 +5384,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.7.0.tgz",
+      "integrity": "sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0",
+        "package-manager-detector": "^1.8.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/fsevents": {
@@ -4892,9 +5585,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5796,6 +6489,99 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/knip": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.34.0.tgz",
+      "integrity": "sha512-bbHIrnGspYwe4EBPjjx+lvkUor0F2qfKQc5BPzPI4SOAImYA+k2ueVpIcF7d/W1LEVT7XoJUPt6zELeGZhXBgA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.7.0",
+        "get-tsconfig": "4.14.3",
+        "jiti": "^2.7.0",
+        "oxc-parser": "^0.147.0",
+        "oxc-resolver": "11.24.2",
+        "picomatch": "^4.0.7",
+        "smol-toml": "^1.8.0",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.17",
+        "unbash": "^4.0.10",
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/knip/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/knip/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/knip/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
@@ -6688,6 +7474,84 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.147.0.tgz",
+      "integrity": "sha512-5xaug6t7GfV3BO5Iv+xHW1rmQkDEQ3BEu3L8g3InsvWO5i8CYGc4tCZ2X985QcwWNycFJam+aOns6Nr2XAThTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.147.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.147.0",
+        "@oxc-parser/binding-android-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-x64": "0.147.0",
+        "@oxc-parser/binding-freebsd-x64": "0.147.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.147.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.147.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.147.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6726,6 +7590,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pako": {
       "version": "2.1.0",
@@ -7718,6 +8589,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8232,6 +9116,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.11.tgz",
+      "integrity": "sha512-FoSOKV7NEofQSkAefMVHam4ZPKYMxjAydxiV72UFEDNV/YofxjGfiZ2A9pZjdL/lRJzTjcu4PABo1JYJX8N5iQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/unbox-primitive": {
@@ -8873,6 +9767,16 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
@@ -9181,6 +10085,16 @@
       "dependencies": {
         "@zarrita/storage": "^0.2.0",
         "numcodecs": "^0.3.2"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zstddec": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src tests",
     "lint-ci": "eslint src tests --max-warnings 0",
     "lint:fix": "eslint src tests --fix",
+    "knip": "knip --dependencies --exports",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
+    "@eslint/js": "^9.39.4",
     "@types/d3-delaunay": "^6.0.4",
     "@types/d3-geo": "^3.1.1",
     "@types/geojson": "7946.0.16",
@@ -82,6 +84,7 @@
     "eslint-plugin-vue": "10.9",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
+    "knip": "6.34.0",
     "lint-staged": "^17.0.7",
     "prettier": "^3.8.4",
     "sass": "~1.89.2",

--- a/src/lib/data/coordinateVariables.ts
+++ b/src/lib/data/coordinateVariables.ts
@@ -7,23 +7,19 @@ import { ZarrDataManager } from "./ZarrDataManager.ts";
 import { type TSources } from "@/lib/types/GlobeTypes.ts";
 
 const WGS84 = "EPSG:4326";
-const WEB_MERCATOR = "EPSG:3857";
 
-export const ProjectedCoordinateName = {
+const ProjectedCoordinateName = {
   X: "x",
   Y: "y",
 } as const;
 
-export type TProjectedCoordinateName =
-  (typeof ProjectedCoordinateName)[keyof typeof ProjectedCoordinateName];
-
-export const CrsWktAttributeName = {
+const CrsWktAttributeName = {
   CRS_WKT: "crs_wkt",
   SPATIAL_REF: "spatial_ref",
   PROJECTION: "projection",
 } as const;
 
-export type TCrsWktAttributeName =
+type TCrsWktAttributeName =
   (typeof CrsWktAttributeName)[keyof typeof CrsWktAttributeName];
 
 export function isWebMercatorCRS(crsWkt: string): boolean {
@@ -65,16 +61,6 @@ function transformProjectedAxesToLonLat(
   }
 
   return { longitudes, latitudes };
-}
-
-export function webMercatorToLonLat(
-  x: Float32Array,
-  y: Float32Array
-): {
-  longitudes: Float32Array;
-  latitudes: Float32Array;
-} {
-  return transformProjectedAxesToLonLat(x, y, WEB_MERCATOR);
 }
 
 export function projectedAxisCoordinatesToLonLat(
@@ -272,16 +258,14 @@ function getVariableLocalName(variable: string) {
   return lastSlashIndex === -1 ? variable : variable.slice(lastSlashIndex + 1);
 }
 
-export function hasUnits(
-  maybeHasUnits: unknown
-): maybeHasUnits is { units: string } {
+function hasUnits(maybeHasUnits: unknown): maybeHasUnits is { units: string } {
   if (typeof maybeHasUnits !== "object" || maybeHasUnits === null) {
     return false;
   }
   return typeof (maybeHasUnits as { units: string }).units === "string";
 }
 
-export function isLongitudeVariable(name: string, attrs: unknown) {
+function isLongitudeVariable(name: string, attrs: unknown) {
   const variableName = getVariableLocalName(name);
   return (
     (hasUnits(attrs) && !!attrs.units.match(/degrees?_?(E|east)/)) ||
@@ -301,7 +285,7 @@ export function isLongitudeName(name: string) {
   );
 }
 
-export function isLatitudeVariable(name: string, attrs: unknown) {
+function isLatitudeVariable(name: string, attrs: unknown) {
   const variableName = getVariableLocalName(name);
   return (
     (hasUnits(attrs) && !!attrs.units.match(/degrees?_?(N|north)/)) ||

--- a/src/lib/data/liveTimestep.ts
+++ b/src/lib/data/liveTimestep.ts
@@ -16,8 +16,8 @@ import type { TSources } from "@/lib/types/GlobeTypes.ts";
  * Both return JSON of the form `{ "timestep": <index> }`, where the index is a
  * valid index into the store's (fixed) time dimension.
  */
-export const CURRENT_TIMESTEP_ENDPOINT = "current-timestep";
-export const NEXT_TIMESTEP_ENDPOINT = "next-timestep";
+const CURRENT_TIMESTEP_ENDPOINT = "current-timestep";
+const NEXT_TIMESTEP_ENDPOINT = "next-timestep";
 
 /**
  * Resolve the base HTTP URL of the Zarr store backing a live dataset.

--- a/src/lib/data/sourceIndexing.ts
+++ b/src/lib/data/sourceIndexing.ts
@@ -215,22 +215,22 @@ async function processZarrVariables(
   );
 
   // Filter and merge datasources
-  const datasources = candidates
+  const entries = candidates
     .filter((promise) => promise.status === "fulfilled")
     .map((promise) => promise.value)
     .filter((obj) => Object.keys(obj).length > 0)
     .map((obj) => {
       // Filter out variables that are actually dimensions or coordinates
       const varname = Object.keys(obj)[0];
-      if (dimensions.has(varname)) {
-        const hiddenObject = { [varname]: { ...obj[varname], hidden: true } };
-        return hiddenObject;
-      }
-      return obj;
-    })
-    .reduce((a, b) => ({ ...a, ...b }), {});
+      return [
+        varname,
+        dimensions.has(varname)
+          ? { ...obj[varname], hidden: true }
+          : obj[varname],
+      ] as const;
+    });
 
-  return datasources;
+  return Object.fromEntries(entries);
 }
 
 function createIndex(

--- a/src/lib/data/sourceIndexing.ts
+++ b/src/lib/data/sourceIndexing.ts
@@ -190,13 +190,24 @@ async function collectVariables(
   dimensions: Set<string>;
 }> {
   const dimensions = new Set<string>();
-  const candidates = await Promise.allSettled(
-    store
-      .contents()
-      .map((content) =>
-        collectVariable(root, src, datasetPath, dimensions, content)
-      )
-  );
+  const contents = store.contents().filter(({ kind }) => kind === "array");
+  const candidates: PromiseSettledResult<Record<string, TDataSource>>[] = [];
+
+  const batchSize = 200;
+  for (let offset = 0; offset < contents.length; offset += batchSize) {
+    if (offset > 0) {
+      // Yield a task so the browser can handle input and repaint between batches.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    const batch = await Promise.allSettled(
+      contents
+        .slice(offset, offset + batchSize)
+        .map((content) =>
+          collectVariable(root, src, datasetPath, dimensions, content)
+        )
+    );
+    candidates.push(...batch);
+  }
 
   return { candidates, dimensions };
 }

--- a/src/lib/data/timeHandling.ts
+++ b/src/lib/data/timeHandling.ts
@@ -38,7 +38,7 @@ function parseTimeUnits(units: string): { interval: string; ref: Dayjs } {
  * Converts a datetime to a numeric time value using the given units.
  * Assumes standard calendar (no leap seconds unless stated otherwise).
  */
-export function encodeTime(datetime: Dayjs, attrs: zarr.Attributes): number {
+function encodeTime(datetime: Dayjs, attrs: zarr.Attributes): number {
   const units: string = attrs.units as string;
   const { interval, ref } = parseTimeUnits(units);
 

--- a/src/lib/data/variableDecoding.ts
+++ b/src/lib/data/variableDecoding.ts
@@ -48,29 +48,6 @@ export function getFillValue(
   return NaN;
 }
 
-/**
- * Create a predicate that returns true when a value equals the dataset's
- * missing or fill value (or is NaN).
- */
-export function createMissingOrFillPredicate(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
-) {
-  const missingValue = getMissingValue(datavar);
-  const fillValue = getFillValue(datavar);
-  return (value: number) => {
-    if (Number.isNaN(value)) {
-      return true;
-    }
-    if (value === missingValue) {
-      return true;
-    }
-    if (value === fillValue) {
-      return true;
-    }
-    return false;
-  };
-}
-
 function getAttributeNumber(
   attributes: zarr.Attributes | undefined,
   key: string,

--- a/src/lib/grids/irregularCalculations.ts
+++ b/src/lib/grids/irregularCalculations.ts
@@ -16,7 +16,7 @@ export type TIrregularGridData = {
   estimatedSpacing: number;
 };
 
-export function estimateIrregularAverageSpacing(
+function estimateIrregularAverageSpacing(
   positions: Float32Array,
   sampleSize = 5000
 ) {

--- a/src/lib/grids/irregularDelaunayCalculations.ts
+++ b/src/lib/grids/irregularDelaunayCalculations.ts
@@ -87,7 +87,7 @@ function isValidTriangle(
   return true;
 }
 
-export function computeDelaunayTriangulation(
+function computeDelaunayTriangulation(
   latitudes: Float32Array,
   longitudes: Float32Array
 ): Uint32Array {

--- a/src/lib/grids/triangularWorkerProtocol.ts
+++ b/src/lib/grids/triangularWorkerProtocol.ts
@@ -14,7 +14,7 @@ export const TriangularWorkerOperation = {
   DATA: "data",
 } as const;
 
-export type TTriangularWorkerOperation =
+type TTriangularWorkerOperation =
   (typeof TriangularWorkerOperation)[keyof typeof TriangularWorkerOperation];
 
 export type TTriangularGeometryWorkerRequest = {

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -258,14 +258,3 @@ export async function getLandSeaMask(
     return undefined;
   }
 }
-
-/**
- * Update the projection uniforms on an existing land/sea mask mesh.
- * This is the fast path for projection center changes - no geometry rebuild needed.
- */
-export function updateLandSeaMaskProjection(
-  mask: THREE.Object3D | undefined,
-  projectionHelper: ProjectionHelper
-): void {
-  updateEquirectLayerProjection(mask, projectionHelper);
-}

--- a/src/lib/layers/landSeaMask.ts
+++ b/src/lib/layers/landSeaMask.ts
@@ -13,7 +13,6 @@ import {
   createEquirectLayerMesh,
   createLayerCanvas,
   LAND_SEA_MASK_MODES,
-  updateEquirectLayerProjection,
   type TLandSeaMaskMode,
 } from "./equirectLayer.ts";
 import { ResourceCache } from "./ResourceCache.ts";

--- a/src/lib/layers/textureLayerFormats.ts
+++ b/src/lib/layers/textureLayerFormats.ts
@@ -1,4 +1,4 @@
-export const TEXTURE_LAYER_MIME_TYPES = {
+const TEXTURE_LAYER_MIME_TYPES = {
   JPEG: "image/jpeg",
   PNG: "image/png",
   TIFF_SHORT: "image/tif",
@@ -13,7 +13,7 @@ export const TEXTURE_LAYER_MIME_TYPES = {
 export type TTextureLayerMimeType =
   (typeof TEXTURE_LAYER_MIME_TYPES)[keyof typeof TEXTURE_LAYER_MIME_TYPES];
 
-export const TEXTURE_LAYER_FILE_EXTENSIONS = {
+const TEXTURE_LAYER_FILE_EXTENSIONS = {
   GEOTIFF: ".geotiff",
   TIF: ".tif",
   TIFF: ".tiff",

--- a/src/lib/projection/projectionShaders.ts
+++ b/src/lib/projection/projectionShaders.ts
@@ -11,9 +11,6 @@ export const PROJECTION_TYPE_BY_MODE = {
   [PROJECTION_TYPES.AZIMUTHAL_HYBRID]: 7,
 } as const;
 
-export type TProjectionTypeId =
-  (typeof PROJECTION_TYPE_BY_MODE)[TProjectionType];
-
 /**
  * Get the projection type constant for a given projection mode string
  */

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -118,7 +118,7 @@ export function makeGpuProjectedTextureMaterial(
  * Create a GPU-projected mesh material for vertex-valued grids.
  * Projection is done on the GPU, allowing instant center changes.
  */
-export function makeGpuProjectedMeshMaterial(
+function makeGpuProjectedMeshMaterial(
   colormap: TColorMap = "turbo",
   addOffset: 1.0 | 0.0 = 0.0,
   scaleFactor: -1.0 | 1.0 = 1.0

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -86,7 +86,7 @@ export type TLayerEntry = {
   maskMode: TLandSeaMaskMode;
 };
 
-export function normalizeLayerOpacity(opacity: number) {
+function normalizeLayerOpacity(opacity: number) {
   if (!Number.isFinite(opacity)) {
     return LAYER_OPACITY.MAX;
   }

--- a/src/ui/common/useToast.ts
+++ b/src/ui/common/useToast.ts
@@ -9,14 +9,14 @@ export const ToastType = {
 
 export type TToastType = (typeof ToastType)[keyof typeof ToastType];
 
-export type TToast = {
+type TToast = {
   id: number;
   summary: string;
   detail?: string;
   type: TToastType;
 };
 
-export type TAddToastOptions = {
+type TAddToastOptions = {
   detail?: string;
   duration?: number;
   type?: TToastType;

--- a/src/ui/grids/composables/gridHoverUtils.ts
+++ b/src/ui/grids/composables/gridHoverUtils.ts
@@ -1,8 +1,5 @@
-import { around } from "geokdbush";
-import KDBush from "kdbush";
 import { onBeforeUnmount, shallowRef, watch, type ShallowRef } from "vue";
 
-import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
   HOVERED_GRID_POINT_STATUS,
   useGlobeControlStore,
@@ -32,47 +29,6 @@ export type TGeoSample = {
 export type TGeoSampleIndex = {
   findNearest(lat: number, lon: number): TGeoSample | null;
 };
-
-function clampLatitude(lat: number) {
-  return Math.max(-90, Math.min(90, lat));
-}
-
-export function createGeoSampleIndex(
-  samples: TGeoSample[],
-  bucketSizeDegrees = 5
-): TGeoSampleIndex {
-  void bucketSizeDegrees;
-
-  const normalizedSamples = samples.map((sample) => {
-    return {
-      ...sample,
-      lat: clampLatitude(sample.lat),
-      lon: ProjectionHelper.normalizeLongitude(sample.lon),
-    };
-  });
-
-  const index = new KDBush(normalizedSamples.length);
-  for (const sample of normalizedSamples) {
-    index.add(sample.lon, sample.lat);
-  }
-  index.finish();
-
-  return {
-    findNearest(lat, lon) {
-      const nearest = around(
-        index,
-        ProjectionHelper.normalizeLongitude(lon),
-        clampLatitude(lat),
-        1
-      );
-      const nearestIndex = nearest[0];
-      if (nearestIndex === undefined) {
-        return null;
-      }
-      return normalizedSamples[nearestIndex] ?? null;
-    },
-  };
-}
 
 function isMissingGridValue(
   value: number,

--- a/src/ui/overlays/InfoPanel.vue
+++ b/src/ui/overlays/InfoPanel.vue
@@ -313,11 +313,8 @@ async function loadGroupAttrsChain(
     try {
       const group = await ZarrDataManager.getGroup(varSource, groupPath);
       chain.push({ path: groupPath || "/", attrs: group.attrs });
-    } catch (err) {
-      logError(
-        err,
-        `Error fetching attributes for group "${groupPath || "/"}"`
-      );
+    } catch {
+      // Ignore group issues
     }
   }
   return chain;

--- a/src/ui/overlays/controls/colorbarUtils.ts
+++ b/src/ui/overlays/controls/colorbarUtils.ts
@@ -2,26 +2,6 @@
 
 import { formatValue } from "@/utils/formatValue";
 
-/**
- * Returns the step size for a data range: two orders of magnitude below the
- * range itself. Used by BoundsControls (input step) and ColormapControls
- * (rounding dragged values) to keep numbers readable.
- * Returns "any" when the range is zero (unknown / degenerate).
- */
-export function dataRangeStep(
-  low: number | undefined,
-  high: number | undefined
-): number | "any" {
-  if (low === undefined || high === undefined) {
-    return "any";
-  }
-  const range = Math.abs(Number(high) - Number(low));
-  if (range === 0) {
-    return "any";
-  }
-  return Math.pow(10, Math.floor(Math.log10(range)) - 2);
-}
-
 /** Round a value to the step implied by the data range. */
 export function roundToDataPrecision(
   value: number,

--- a/src/ui/overlays/controls/useTimeAnimation.ts
+++ b/src/ui/overlays/controls/useTimeAnimation.ts
@@ -12,15 +12,14 @@ import { isTimeUnits } from "@/lib/data/timeHandling.ts";
 import type { TDimensionRange, TVarInfo } from "@/lib/types/GlobeTypes.ts";
 import { useGlobeControlStore } from "@/store/store.ts";
 
-export const PLAYBACK_SPEED = {
+const PLAYBACK_SPEED = {
   SLOW: 0,
   NORMAL: 1,
   FAST: 2,
   MAX: 3,
 } as const;
 
-export type TPlaybackSpeed =
-  (typeof PLAYBACK_SPEED)[keyof typeof PLAYBACK_SPEED];
+type TPlaybackSpeed = (typeof PLAYBACK_SPEED)[keyof typeof PLAYBACK_SPEED];
 
 type TPlayableDimensionRange = Exclude<TDimensionRange, null>;
 

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -13,7 +13,7 @@ export type TCatalog = {
   datasets: TCatalogEntry[];
 };
 
-export function isCatalog(data: unknown): data is TCatalog {
+function isCatalog(data: unknown): data is TCatalog {
   return (
     typeof data === "object" &&
     data !== null &&

--- a/tests/unit/lib/data/sourceIndexing.test.ts
+++ b/tests/unit/lib/data/sourceIndexing.test.ts
@@ -1,0 +1,70 @@
+import { expect, it } from "vitest";
+
+import { hideFormulaTermVariablesWithoutStandardName } from "@/lib/data/sourceIndexing.ts";
+import type { TDataSource } from "@/lib/types/GlobeTypes.ts";
+
+const CFAttribute = {
+  FORMULA_TERMS: "formula_terms",
+  STANDARD_NAME: "standard_name",
+} as const;
+
+function datasource(attrs: Record<string, unknown> = {}): TDataSource {
+  return {
+    store: "store",
+    dataset: "",
+    attrs,
+  };
+}
+
+it("hides formula-term variables that have no standard name", () => {
+  const datasources = {
+    atmosphere: datasource({
+      [CFAttribute.FORMULA_TERMS]: "ap: ap b: b ps: ps",
+    }),
+    ap: datasource(),
+    b: datasource({
+      [CFAttribute.STANDARD_NAME]:
+        "atmosphere_hybrid_sigma_pressure_coordinate",
+    }),
+    ps: datasource(),
+    unrelated: datasource(),
+  };
+
+  hideFormulaTermVariablesWithoutStandardName(datasources);
+
+  expect(datasources.ap.hidden).toBe(true);
+  expect(datasources.b.hidden).toBeUndefined();
+  expect(datasources.ps.hidden).toBe(true);
+  expect(datasources.unrelated.hidden).toBeUndefined();
+});
+
+it("keeps valid formula terms while ignoring malformed tokens", () => {
+  const datasources = {
+    atmosphere: datasource({
+      [CFAttribute.FORMULA_TERMS]: "ap: ap malformed",
+    }),
+    ap: datasource(),
+    malformed: datasource(),
+  };
+
+  hideFormulaTermVariablesWithoutStandardName(datasources);
+
+  expect(datasources.ap.hidden).toBe(true);
+  expect(datasources.malformed.hidden).toBeUndefined();
+});
+
+it.each([undefined, 42, "", "ap", "ap:", ":ap", "ap:ap:extra"])(
+  "ignores formula_terms without valid pairs: %s",
+  (formulaTerms) => {
+    const datasources = {
+      atmosphere: datasource({
+        [CFAttribute.FORMULA_TERMS]: formulaTerms,
+      }),
+      ap: datasource(),
+    };
+
+    hideFormulaTermVariablesWithoutStandardName(datasources);
+
+    expect(datasources.ap.hidden).toBeUndefined();
+  }
+);

--- a/tests/unit/lib/data/sourceIndexingBatching.test.ts
+++ b/tests/unit/lib/data/sourceIndexingBatching.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable camelcase -- Zarr metadata uses snake_case keys. */
+import { expect, it, vi } from "vitest";
+import * as zarr from "zarrita";
+
+import { indexFromZarr } from "@/lib/data/sourceIndexing.ts";
+
+function metadataResponse(names: string[]) {
+  const metadata: Record<string, unknown> = {
+    ".zgroup": { zarr_format: 2 },
+    ".zattrs": {},
+  };
+  for (const name of names) {
+    metadata[`${name}/.zarray`] = {
+      zarr_format: 2,
+      shape: [1],
+      chunks: [1],
+      dtype: "<f4",
+      compressor: null,
+      filters: null,
+      fill_value: 0,
+      order: "C",
+    };
+    metadata[`${name}/.zattrs`] = {
+      _ARRAY_DIMENSIONS: ["cell"],
+      ...(name === names.at(-1) ? { coordinates: "coordinate" } : {}),
+    };
+  }
+  return new Response(
+    JSON.stringify({ zarr_consolidated_format: 1, metadata })
+  );
+}
+
+it("yields during indexing and resolves coordinates referenced by later batches", async () => {
+  const names = [
+    "group/coordinate",
+    ...Array.from({ length: 400 }, (_, index) => `group/variable${index}`),
+  ];
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(metadataResponse(names));
+  const openSpy = vi.spyOn(zarr.open, "v2");
+  try {
+    const openedAtYield = new Promise<number>((resolve) => {
+      setTimeout(() => {
+        resolve(
+          openSpy.mock.calls.filter(([, options]) => options?.kind === "array")
+            .length
+        );
+      }, 0);
+    });
+    const loading = indexFromZarr("https://example.test/data.zarr");
+    const opened = await openedAtYield;
+    const index = await loading;
+
+    expect(opened).toBeGreaterThan(0);
+    expect(opened).toBeLessThan(names.length);
+    const sources = index.levels[0].datasources;
+    expect(Object.keys(sources)).toEqual(names);
+    expect(sources["group/coordinate"].hidden).toBe(true);
+    expect(sources["group/variable399"].hidden).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  } finally {
+    openSpy.mockRestore();
+    fetchMock.mockRestore();
+  }
+});

--- a/tests/unit/lib/data/sourceIndexingMerge.test.ts
+++ b/tests/unit/lib/data/sourceIndexingMerge.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable camelcase -- Zarr metadata uses snake_case keys. */
+import { expect, it, vi } from "vitest";
+
+import { indexFromZarr } from "@/lib/data/sourceIndexing.ts";
+
+it("preserves grouped variables, coordinates, and special keys when merging", async () => {
+  const names = [
+    "first/temperature",
+    "second/temperature",
+    "first/cell",
+    "second/cell",
+    "__proto__",
+  ];
+  const metadata: Record<string, unknown> = {
+    ".zgroup": { zarr_format: 2 },
+    ".zattrs": {},
+    "first/.zgroup": { zarr_format: 2 },
+    "second/.zgroup": { zarr_format: 2 },
+  };
+  for (const name of names) {
+    metadata[`${name}/.zarray`] = {
+      zarr_format: 2,
+      shape: [1],
+      chunks: [1],
+      dtype: "<f4",
+      compressor: null,
+      filters: null,
+      fill_value: 0,
+      order: "C",
+    };
+    metadata[`${name}/.zattrs`] = { _ARRAY_DIMENSIONS: ["cell"] };
+  }
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(
+      new Response(JSON.stringify({ zarr_consolidated_format: 1, metadata }))
+    );
+  try {
+    const index = await indexFromZarr("https://example.test/data.zarr");
+    const sources = index.levels[0].datasources;
+    expect(Object.keys(sources)).toEqual(names);
+    expect(sources["first/temperature"].hidden).toBe(false);
+    expect(sources["second/temperature"].hidden).toBe(false);
+    expect(sources["first/cell"].hidden).toBe(true);
+    expect(sources["second/cell"].hidden).toBe(true);
+    expect(Object.hasOwn(sources, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(sources)).toBe(Object.prototype);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  } finally {
+    fetchMock.mockRestore();
+  }
+});


### PR DESCRIPTION
* introduced [Knip](https://knip.dev/) into the CI in order to find dead code
* removed the found dead code
* applied some smaller improvements for source indexing (like removing `reduce`) because it created a lot of unnecessary load for larger datasets (large in terms of many variables and groups). The use case for this was loading the whole km-scale cloud as a single dataset into gridlook (I am not going to share the link to spare the system...)