### PR TITLE
Feat/webworker healpix

### DIFF
--- a/src/lib/grids/gridGeometryWorkerClient.ts
+++ b/src/lib/grids/gridGeometryWorkerClient.ts
@@ -19,19 +19,26 @@ type TWorkerRequest<TRequest> = {
   transfer: Transferable[];
 };
 
-type TBuildResult<TMetadata extends TGridGeometryWorkerMetadata> = {
+type TBuildResult<
+  TMetadata extends TGridGeometryWorkerMetadata,
+  THoverIndex,
+> = {
   metadata: TMetadata;
-  hoverIndexData: TSerializedGeoSampleIndexData;
+  hoverIndexData: THoverIndex;
 };
 
-type TActiveBuild<TMetadata extends TGridGeometryWorkerMetadata, TBatch> = {
+type TActiveBuild<
+  TMetadata extends TGridGeometryWorkerMetadata,
+  TBatch,
+  THoverIndex,
+> = {
   requestId: number;
   worker: Worker;
   callbacks: TGridGeometryBuildCallbacks<TMetadata, TBatch>;
   metadata: TMetadata | null;
   receivedBatchIndexes: Set<number>;
-  hoverIndexData: TSerializedGeoSampleIndexData | null;
-  resolve: (value: TBuildResult<TMetadata>) => void;
+  hoverIndexData: THoverIndex | null;
+  resolve: (value: TBuildResult<TMetadata, THoverIndex>) => void;
   reject: (reason?: unknown) => void;
 };
 
@@ -46,8 +53,11 @@ export function createGridGeometryWorkerClient<
   TRequest,
   TMetadata extends TGridGeometryWorkerMetadata,
   TBatch extends TGridWorkerBatch = TGridGeometryBatch,
+  THoverIndex = TSerializedGeoSampleIndexData,
 >(createWorker: () => Worker, keepWorkerAlive = false) {
-  let activeBuild: TActiveBuild<TMetadata, TBatch> | null = null;
+  type TResult = TBuildResult<TMetadata, THoverIndex>;
+  type TResponse = TGridGeometryWorkerResponse<TMetadata, TBatch, THoverIndex>;
+  let activeBuild: TActiveBuild<TMetadata, TBatch, THoverIndex> | null = null;
   let nextRequestId = 0;
   let worker: Worker | null = null;
 
@@ -124,7 +134,7 @@ export function createGridGeometryWorkerClient<
 
   function setMetadata(
     activeWorker: Worker,
-    build: TActiveBuild<TMetadata, TBatch>,
+    build: TActiveBuild<TMetadata, TBatch, THoverIndex>,
     metadata: TMetadata
   ) {
     if (
@@ -150,7 +160,7 @@ export function createGridGeometryWorkerClient<
 
   function handleBatch(
     activeWorker: Worker,
-    build: TActiveBuild<TMetadata, TBatch>,
+    build: TActiveBuild<TMetadata, TBatch, THoverIndex>,
     batch: TBatch
   ) {
     if (build.metadata === null) {
@@ -190,7 +200,7 @@ export function createGridGeometryWorkerClient<
       );
       return;
     }
-    const response = message as TGridGeometryWorkerResponse<TMetadata, TBatch>;
+    const response = message as TResponse;
     if (
       !activeBuild ||
       activeBuild.worker !== activeWorker ||
@@ -244,7 +254,7 @@ export function createGridGeometryWorkerClient<
       return Promise.reject(toError(error));
     }
     const activeWorker = worker;
-    return new Promise<TBuildResult<TMetadata>>((resolve, reject) => {
+    return new Promise<TResult>((resolve, reject) => {
       activeBuild = {
         requestId,
         worker: activeWorker,

--- a/src/lib/grids/gridGeometryWorkerProtocol.ts
+++ b/src/lib/grids/gridGeometryWorkerProtocol.ts
@@ -28,6 +28,7 @@ type TGridGeometryWorkerResponseBase = {
 export type TGridGeometryWorkerResponse<
   TMetadata extends TGridGeometryWorkerMetadata,
   TBatch extends TGridWorkerBatch = TGridGeometryBatch,
+  THoverIndex = TSerializedGeoSampleIndexData,
 > =
   | (TGridGeometryWorkerResponseBase & {
       type: typeof GridGeometryWorkerMessageType.METADATA;
@@ -39,7 +40,7 @@ export type TGridGeometryWorkerResponse<
     })
   | (TGridGeometryWorkerResponseBase & {
       type: typeof GridGeometryWorkerMessageType.HOVER_INDEX;
-      hoverIndexData: TSerializedGeoSampleIndexData;
+      hoverIndexData: THoverIndex;
     })
   | (TGridGeometryWorkerResponseBase & {
       type: typeof GridGeometryWorkerMessageType.DONE;

--- a/src/lib/grids/healpix.worker.ts
+++ b/src/lib/grids/healpix.worker.ts
@@ -1,0 +1,101 @@
+/// <reference lib="webworker" />
+
+import { GridGeometryWorkerMessageType } from "./gridGeometryWorkerProtocol.ts";
+import {
+  buildHealpixGeometry,
+  buildHealpixTexture,
+  HEALPIX_NUMCHUNKS,
+} from "./healpixCalculations.ts";
+import type {
+  THealpixBatch,
+  THealpixWorkerRequest,
+  THealpixWorkerResponse,
+} from "./healpixWorkerProtocol.ts";
+
+import { decodeVariableDataInPlace } from "@/lib/data/variableDecoding.ts";
+import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
+
+const workerScope = self as unknown as DedicatedWorkerGlobalScope;
+
+function postResponse(
+  response: THealpixWorkerResponse,
+  transfer: Transferable[] = []
+) {
+  workerScope.postMessage(response, transfer);
+}
+
+function postBatch(requestId: number, batch: THealpixBatch) {
+  postResponse(
+    { requestId, type: GridGeometryWorkerMessageType.BATCH, batch },
+    [
+      batch.positionValues.buffer,
+      batch.latLonValues.buffer,
+      batch.uv.buffer,
+      batch.indices.buffer,
+      batch.dataValues.buffer,
+      batch.histogramSummary.bins.buffer,
+    ]
+  );
+}
+
+async function buildGrid(request: THealpixWorkerRequest) {
+  // Install the message handler before WASM initialization yields to the event loop.
+  const { Grid } = await import("healpix-geo");
+  using grid = new Grid(request.grid);
+  using textureGrid = grid.replace({ level: 0, scheme: "nested" });
+  const { requestId, data } = request;
+  if (
+    data.length !==
+    (request.cells?.length ?? HEALPIX_NUMCHUNKS * grid.nside ** 2)
+  ) {
+    throw new Error("HEALPix data length does not match the grid.");
+  }
+  decodeVariableDataInPlace(
+    data,
+    request.attributes,
+    request.missingValue,
+    request.fillValue
+  );
+  const cellIndex = request.cells
+    ? new Map(request.cells.map((cell, index) => [cell, index]))
+    : undefined;
+  const mortonIndices = grid.bitCombineTable(grid.nside);
+  const projection = new ProjectionHelper(
+    request.projectionType,
+    request.projectionCenter
+  );
+  postResponse({
+    requestId,
+    type: GridGeometryWorkerMessageType.METADATA,
+    metadata: { totalBatches: HEALPIX_NUMCHUNKS },
+  });
+  for (let batchIndex = 0; batchIndex < HEALPIX_NUMCHUNKS; batchIndex++) {
+    const batch = {
+      batchIndex,
+      ...buildHealpixGeometry(textureGrid, BigInt(batchIndex), 65, projection),
+      ...buildHealpixTexture(data, batchIndex, mortonIndices, cellIndex),
+    };
+    postBatch(requestId, batch);
+  }
+  postResponse(
+    {
+      requestId,
+      type: GridGeometryWorkerMessageType.HOVER_INDEX,
+      hoverIndexData: data,
+    },
+    [data.buffer]
+  );
+  postResponse({ requestId, type: GridGeometryWorkerMessageType.DONE });
+}
+
+workerScope.onmessage = async (event: MessageEvent<THealpixWorkerRequest>) => {
+  try {
+    await buildGrid(event.data);
+  } catch (error) {
+    postResponse({
+      requestId: event.data.requestId,
+      type: GridGeometryWorkerMessageType.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src/lib/grids/healpix.worker.ts
+++ b/src/lib/grids/healpix.worker.ts
@@ -4,7 +4,6 @@ import { GridGeometryWorkerMessageType } from "./gridGeometryWorkerProtocol.ts";
 import {
   buildHealpixGeometry,
   buildHealpixTexture,
-  HEALPIX_NUMCHUNKS,
 } from "./healpixCalculations.ts";
 import type {
   THealpixBatch,
@@ -24,7 +23,10 @@ function postResponse(
   workerScope.postMessage(response, transfer);
 }
 
-function postBatch(requestId: number, batch: THealpixBatch) {
+function postBatch(
+  requestId: number,
+  batch: Omit<THealpixBatch, "dataValues">
+) {
   postResponse(
     { requestId, type: GridGeometryWorkerMessageType.BATCH, batch },
     [
@@ -32,7 +34,6 @@ function postBatch(requestId: number, batch: THealpixBatch) {
       batch.latLonValues.buffer,
       batch.uv.buffer,
       batch.indices.buffer,
-      batch.dataValues.buffer,
       batch.histogramSummary.bins.buffer,
     ]
   );
@@ -43,11 +44,11 @@ async function buildGrid(request: THealpixWorkerRequest) {
   const { Grid } = await import("healpix-geo");
   using grid = new Grid(request.grid);
   using textureGrid = grid.replace({ level: 0, scheme: "nested" });
-  const { requestId, data } = request;
-  if (
-    data.length !==
-    (request.cells?.length ?? HEALPIX_NUMCHUNKS * grid.nside ** 2)
-  ) {
+  const { requestId, data, faceIndex } = request;
+  if (!Number.isInteger(faceIndex) || faceIndex < 0 || faceIndex >= 12) {
+    throw new Error("Invalid HEALPix face index.");
+  }
+  if (data.length !== (request.cells?.length ?? grid.nside ** 2)) {
     throw new Error("HEALPix data length does not match the grid.");
   }
   decodeVariableDataInPlace(
@@ -59,7 +60,6 @@ async function buildGrid(request: THealpixWorkerRequest) {
   const cellIndex = request.cells
     ? new Map(request.cells.map((cell, index) => [cell, index]))
     : undefined;
-  const mortonIndices = grid.bitCombineTable(grid.nside);
   const projection = new ProjectionHelper(
     request.projectionType,
     request.projectionCenter
@@ -67,23 +67,26 @@ async function buildGrid(request: THealpixWorkerRequest) {
   postResponse({
     requestId,
     type: GridGeometryWorkerMessageType.METADATA,
-    metadata: { totalBatches: HEALPIX_NUMCHUNKS },
+    metadata: { totalBatches: 1 },
   });
-  for (let batchIndex = 0; batchIndex < HEALPIX_NUMCHUNKS; batchIndex++) {
-    const batch = {
-      batchIndex,
-      ...buildHealpixGeometry(textureGrid, BigInt(batchIndex), 65, projection),
-      ...buildHealpixTexture(data, batchIndex, mortonIndices, cellIndex),
-    };
-    postBatch(requestId, batch);
-  }
+  const { dataValues, histogramSummary } = buildHealpixTexture(
+    data,
+    faceIndex,
+    grid.nside,
+    cellIndex
+  );
+  postBatch(requestId, {
+    batchIndex: 0,
+    ...buildHealpixGeometry(textureGrid, BigInt(faceIndex), 65, projection),
+    histogramSummary,
+  });
   postResponse(
     {
       requestId,
       type: GridGeometryWorkerMessageType.HOVER_INDEX,
-      hoverIndexData: data,
+      hoverIndexData: dataValues,
     },
-    [data.buffer]
+    [dataValues.buffer]
   );
   postResponse({ requestId, type: GridGeometryWorkerMessageType.DONE });
 }

--- a/src/lib/grids/healpix.worker.ts
+++ b/src/lib/grids/healpix.worker.ts
@@ -57,9 +57,6 @@ async function buildGrid(request: THealpixWorkerRequest) {
     request.missingValue,
     request.fillValue
   );
-  const cellIndex = request.cells
-    ? new Map(request.cells.map((cell, index) => [cell, index]))
-    : undefined;
   const projection = new ProjectionHelper(
     request.projectionType,
     request.projectionCenter
@@ -69,16 +66,15 @@ async function buildGrid(request: THealpixWorkerRequest) {
     type: GridGeometryWorkerMessageType.METADATA,
     metadata: { totalBatches: 1 },
   });
-  const { dataValues, histogramSummary } = buildHealpixTexture(
-    data,
-    faceIndex,
-    grid.nside,
-    cellIndex
-  );
+  const { dataValues, histogramSummary, width, height, dataRect } =
+    buildHealpixTexture(data, faceIndex, grid.nside, request.cells);
   postBatch(requestId, {
     batchIndex: 0,
     ...buildHealpixGeometry(textureGrid, BigInt(faceIndex), 65, projection),
     histogramSummary,
+    width,
+    height,
+    dataRect,
   });
   postResponse(
     {

--- a/src/lib/grids/healpixCalculations.ts
+++ b/src/lib/grids/healpixCalculations.ts
@@ -1,0 +1,129 @@
+import type { Grid } from "healpix-geo";
+
+import type { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
+import { buildHistogramSummary } from "@/utils/histogram.ts";
+
+export const HEALPIX_NUMCHUNKS = 12;
+
+function distanceSquared(
+  x1: number,
+  y1: number,
+  z1: number,
+  x2: number,
+  y2: number,
+  z2: number
+): number {
+  return (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1);
+}
+
+function generateHealpixIndices(positionValues: Float32Array, steps: number) {
+  const indices = [];
+  for (let i = 0; i < steps - 1; ++i) {
+    for (let j = 0; j < steps - 1; ++j) {
+      const a = i * steps + (j + 1);
+      const b = i * steps + j;
+      const c = (i + 1) * steps + j;
+      const d = (i + 1) * steps + (j + 1);
+      const dac2 = distanceSquared(
+        positionValues[3 * a + 0],
+        positionValues[3 * a + 1],
+        positionValues[3 * a + 2],
+        positionValues[3 * c + 0],
+        positionValues[3 * c + 1],
+        positionValues[3 * c + 2]
+      );
+      const dbd2 = distanceSquared(
+        positionValues[3 * b + 0],
+        positionValues[3 * b + 1],
+        positionValues[3 * b + 2],
+        positionValues[3 * d + 0],
+        positionValues[3 * d + 1],
+        positionValues[3 * d + 2]
+      );
+      if (dac2 < dbd2) {
+        indices.push(a, c, d);
+        indices.push(b, c, a);
+      } else {
+        indices.push(a, b, d);
+        indices.push(b, c, d);
+      }
+    }
+  }
+  return indices;
+}
+
+export function buildHealpixGeometry(
+  grid: Grid,
+  ipix: bigint,
+  steps: number,
+  helper: ProjectionHelper
+) {
+  const vertexCount = steps * steps;
+  const positionValues = new Float32Array(vertexCount * 3);
+  const uv = new Float32Array(vertexCount * 2);
+  const latLonValues = new Float32Array(vertexCount * 2);
+  let vertexIndex = 0;
+
+  const coords = grid.vertices(BigInt(ipix), steps);
+  for (let index = 0; index < Math.floor(coords.length / 2); ++index) {
+    const indexLon = 2 * index;
+    const indexLat = 2 * index + 1;
+    const lat = coords[indexLat];
+    const lon = coords[indexLon];
+
+    const u = Math.floor(index / steps) / (steps - 1);
+    const v = (index % steps) / (steps - 1);
+
+    const positionOffset = vertexIndex * 3;
+    helper.projectLatLonToArrays(
+      lat,
+      lon,
+      positionValues,
+      positionOffset,
+      latLonValues,
+      vertexIndex * 2
+    );
+
+    const uvIndex = vertexIndex * 2;
+    uv[uvIndex] = u;
+    uv[uvIndex + 1] = v;
+
+    vertexIndex++;
+  }
+
+  const indices = generateHealpixIndices(positionValues, steps);
+  return {
+    positionValues,
+    uv,
+    latLonValues,
+    indices: new Uint32Array(indices),
+  };
+}
+
+export function buildHealpixTexture(
+  data: Float32Array,
+  batchIndex: number,
+  mortonIndices: BigUint64Array,
+  cellIndex?: Map<number, number>
+) {
+  const dataValues = new Float32Array(mortonIndices.length);
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let index = 0; index < dataValues.length; index++) {
+    const cell = batchIndex * dataValues.length + Number(mortonIndices[index]);
+    const inputIndex = cellIndex ? cellIndex.get(cell) : cell;
+    const value = inputIndex === undefined ? NaN : data[inputIndex];
+    dataValues[index] = value;
+    if (Number.isFinite(value)) {
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  }
+  if (min === Number.POSITIVE_INFINITY) {
+    min = max = NaN;
+  }
+  return {
+    dataValues,
+    histogramSummary: buildHistogramSummary(dataValues, min, max),
+  };
+}

--- a/src/lib/grids/healpixCalculations.ts
+++ b/src/lib/grids/healpixCalculations.ts
@@ -103,15 +103,21 @@ export function buildHealpixGeometry(
 export function buildHealpixTexture(
   data: Float32Array,
   batchIndex: number,
-  mortonIndices: BigUint64Array,
+  nside: number,
   cellIndex?: Map<number, number>
 ) {
-  const dataValues = new Float32Array(mortonIndices.length);
+  const dataValues = new Float32Array(nside * nside);
+  // Interleave each axis separately: O(nside) lookup storage instead of O(nside²).
+  const spread = new Uint32Array(nside);
+  for (let index = 1; index < nside; index++) {
+    spread[index] = spread[index >> 1] * 4 + (index & 1);
+  }
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
   for (let index = 0; index < dataValues.length; index++) {
-    const cell = batchIndex * dataValues.length + Number(mortonIndices[index]);
-    const inputIndex = cellIndex ? cellIndex.get(cell) : cell;
+    const pixel = spread[index % nside] + spread[Math.floor(index / nside)] * 2;
+    const cell = batchIndex * dataValues.length + pixel;
+    const inputIndex = cellIndex ? cellIndex.get(cell) : pixel;
     const value = inputIndex === undefined ? NaN : data[inputIndex];
     dataValues[index] = value;
     if (Number.isFinite(value)) {
@@ -126,4 +132,37 @@ export function buildHealpixTexture(
     dataValues,
     histogramSummary: buildHistogramSummary(dataValues, min, max),
   };
+}
+
+export function getHealpixTextureIndex(pixel: number, nside: number) {
+  let x = 0;
+  let y = 0;
+  for (let bit = 1; pixel > 0; bit *= 2) {
+    x += (pixel % 2) * bit;
+    y += (Math.floor(pixel / 2) % 2) * bit;
+    pixel = Math.floor(pixel / 4);
+  }
+  return y * nside + x;
+}
+
+export function getHealpixFaceRange(
+  faceIndex: number,
+  nside: number,
+  cells?: number[]
+) {
+  const pixelStart = faceIndex * nside * nside;
+  const pixelEnd = pixelStart + nside * nside;
+  if (!cells) {
+    return { start: pixelStart, end: pixelEnd, cells };
+  }
+  // ponytail: 12 scans avoid a full-grid map; index ranges if sparse scans become expensive.
+  let start = cells.length;
+  let end = 0;
+  for (let index = 0; index < cells.length; index++) {
+    if (cells[index] >= pixelStart && cells[index] < pixelEnd) {
+      start = Math.min(start, index);
+      end = index + 1;
+    }
+  }
+  return { start: Math.min(start, end), end, cells: cells.slice(start, end) };
 }

--- a/src/lib/grids/healpixCalculations.ts
+++ b/src/lib/grids/healpixCalculations.ts
@@ -100,12 +100,33 @@ export function buildHealpixGeometry(
   };
 }
 
-export function buildHealpixTexture(
-  data: Float32Array,
-  batchIndex: number,
-  nside: number,
-  cellIndex?: Map<number, number>
-) {
+// A face-local rectangle, normalized to [0, 1] across the whole face, that the
+// texture covers. Lets the shader map a full-face UV onto a texture that only
+// covers the (small) region a regional/sparse dataset actually has data for.
+export type THealpixDataRect = {
+  u: number;
+  v: number;
+  width: number;
+  height: number;
+};
+
+export function decodeHealpixFaceXY(pixel: number) {
+  let x = 0;
+  let y = 0;
+  for (let bit = 1; pixel > 0; bit *= 2) {
+    x += (pixel % 2) * bit;
+    y += (Math.floor(pixel / 2) % 2) * bit;
+    pixel = Math.floor(pixel / 4);
+  }
+  return { x, y };
+}
+
+export function getHealpixTextureIndex(pixel: number, nside: number) {
+  const { x, y } = decodeHealpixFaceXY(pixel);
+  return y * nside + x;
+}
+
+function buildDenseHealpixTexture(data: Float32Array, nside: number) {
   const dataValues = new Float32Array(nside * nside);
   // Interleave each axis separately: O(nside) lookup storage instead of O(nside²).
   const spread = new Uint32Array(nside);
@@ -116,10 +137,64 @@ export function buildHealpixTexture(
   let max = Number.NEGATIVE_INFINITY;
   for (let index = 0; index < dataValues.length; index++) {
     const pixel = spread[index % nside] + spread[Math.floor(index / nside)] * 2;
-    const cell = batchIndex * dataValues.length + pixel;
-    const inputIndex = cellIndex ? cellIndex.get(cell) : pixel;
-    const value = inputIndex === undefined ? NaN : data[inputIndex];
+    const value = data[pixel];
     dataValues[index] = value;
+    if (Number.isFinite(value)) {
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  }
+  if (min === Number.POSITIVE_INFINITY) {
+    min = max = NaN;
+  }
+  return {
+    dataValues,
+    width: nside,
+    height: nside,
+    dataRect: { u: 0, v: 0, width: 1, height: 1 } as THealpixDataRect,
+    histogramSummary: buildHistogramSummary(dataValues, min, max),
+  };
+}
+
+function getFaceCellBBox(cells: number[], faceOffset: number, faceEnd: number) {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = -1;
+  let maxY = -1;
+  for (const cell of cells) {
+    if (cell < faceOffset || cell >= faceEnd) {
+      continue;
+    }
+    const { x, y } = decodeHealpixFaceXY(cell - faceOffset);
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+  }
+  return maxX < minX ? null : { minX, minY, maxX, maxY };
+}
+
+function fillFaceBBoxTexture(
+  data: Float32Array,
+  cells: number[],
+  faceOffset: number,
+  faceEnd: number,
+  bbox: { minX: number; minY: number },
+  width: number,
+  height: number
+) {
+  const { minX, minY } = bbox;
+  const dataValues = new Float32Array(width * height).fill(NaN);
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let index = 0; index < cells.length; index++) {
+    const cell = cells[index];
+    if (cell < faceOffset || cell >= faceEnd) {
+      continue;
+    }
+    const { x, y } = decodeHealpixFaceXY(cell - faceOffset);
+    const value = data[index];
+    dataValues[(y - minY) * width + (x - minX)] = value;
     if (Number.isFinite(value)) {
       min = Math.min(min, value);
       max = Math.max(max, value);
@@ -134,15 +209,64 @@ export function buildHealpixTexture(
   };
 }
 
-export function getHealpixTextureIndex(pixel: number, nside: number) {
-  let x = 0;
-  let y = 0;
-  for (let bit = 1; pixel > 0; bit *= 2) {
-    x += (pixel % 2) * bit;
-    y += (Math.floor(pixel / 2) % 2) * bit;
-    pixel = Math.floor(pixel / 4);
+// A regional/sparse dataset (a "cell" coordinate naming the actual pixels)
+// typically covers only a tiny fraction of a face, especially at deep levels
+// where nside² is far too large to allocate for the whole face. Size the
+// texture to the bounding box of the cells actually present instead.
+function buildSparseHealpixTexture(
+  data: Float32Array,
+  batchIndex: number,
+  nside: number,
+  cells: number[]
+) {
+  const faceOffset = batchIndex * nside * nside;
+  const faceEnd = faceOffset + nside * nside;
+  const bbox = getFaceCellBBox(cells, faceOffset, faceEnd);
+  if (!bbox) {
+    // None of the cells fall in this face.
+    return {
+      dataValues: new Float32Array(0),
+      width: 0,
+      height: 0,
+      dataRect: { u: 0, v: 0, width: 0, height: 0 } as THealpixDataRect,
+      histogramSummary: buildHistogramSummary(new Float32Array(0), NaN, NaN),
+    };
   }
-  return y * nside + x;
+  const { minX, minY, maxX, maxY } = bbox;
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const { dataValues, histogramSummary } = fillFaceBBoxTexture(
+    data,
+    cells,
+    faceOffset,
+    faceEnd,
+    bbox,
+    width,
+    height
+  );
+  return {
+    dataValues,
+    width,
+    height,
+    dataRect: {
+      u: minX / nside,
+      v: minY / nside,
+      width: width / nside,
+      height: height / nside,
+    } as THealpixDataRect,
+    histogramSummary,
+  };
+}
+
+export function buildHealpixTexture(
+  data: Float32Array,
+  batchIndex: number,
+  nside: number,
+  cells?: number[]
+) {
+  return cells
+    ? buildSparseHealpixTexture(data, batchIndex, nside, cells)
+    : buildDenseHealpixTexture(data, nside);
 }
 
 export function getHealpixFaceRange(

--- a/src/lib/grids/healpixWorkerClient.ts
+++ b/src/lib/grids/healpixWorkerClient.ts
@@ -1,0 +1,42 @@
+import {
+  copyGridWorkerArray,
+  createGridGeometryWorkerClient,
+} from "./gridGeometryWorkerClient.ts";
+import type {
+  THealpixBatch,
+  THealpixBuildRequest,
+  THealpixWorkerMetadata,
+  THealpixWorkerRequest,
+} from "./healpixWorkerProtocol.ts";
+
+const client = createGridGeometryWorkerClient<
+  THealpixWorkerRequest,
+  THealpixWorkerMetadata,
+  THealpixBatch,
+  Float32Array
+>(
+  () =>
+    new Worker(new URL("./healpix.worker.ts", import.meta.url), {
+      type: "module",
+    })
+);
+
+export function buildHealpixGrid(
+  request: THealpixBuildRequest,
+  onBatch: (batch: THealpixBatch) => void
+) {
+  return client
+    .build(
+      (requestId) => {
+        const data = copyGridWorkerArray(request.data);
+        return {
+          message: { ...request, requestId, data },
+          transfer: [data.buffer],
+        };
+      },
+      { onMetadata: () => {}, onBatch }
+    )
+    .then(({ hoverIndexData }) => hoverIndexData);
+}
+
+export const terminateHealpixWorker = client.terminate;

--- a/src/lib/grids/healpixWorkerClient.ts
+++ b/src/lib/grids/healpixWorkerClient.ts
@@ -1,7 +1,4 @@
-import {
-  copyGridWorkerArray,
-  createGridGeometryWorkerClient,
-} from "./gridGeometryWorkerClient.ts";
+import { createGridGeometryWorkerClient } from "./gridGeometryWorkerClient.ts";
 import type {
   THealpixBatch,
   THealpixBuildRequest,
@@ -12,31 +9,38 @@ import type {
 const client = createGridGeometryWorkerClient<
   THealpixWorkerRequest,
   THealpixWorkerMetadata,
-  THealpixBatch,
-  Float32Array
+  Omit<THealpixBatch, "dataValues">,
+  Float32Array<ArrayBuffer>
 >(
   () =>
     new Worker(new URL("./healpix.worker.ts", import.meta.url), {
       type: "module",
-    })
+    }),
+  true
 );
 
-export function buildHealpixGrid(
-  request: THealpixBuildRequest,
-  onBatch: (batch: THealpixBatch) => void
-) {
-  return client
-    .build(
-      (requestId) => {
-        const data = copyGridWorkerArray(request.data);
-        return {
-          message: { ...request, requestId, data },
-          transfer: [data.buffer],
-        };
+export async function buildHealpixFace(
+  request: THealpixBuildRequest
+): Promise<THealpixBatch> {
+  let batch!: Omit<THealpixBatch, "dataValues">;
+  const { hoverIndexData } = await client.build(
+    (requestId) => ({
+      message: { ...request, requestId },
+      // The freshly fetched face is owned by this build; transfer without copying it.
+      transfer: [request.data.buffer],
+    }),
+    {
+      onMetadata: () => {},
+      onBatch: (result) => {
+        batch = result;
       },
-      { onMetadata: () => {}, onBatch }
-    )
-    .then(({ hoverIndexData }) => hoverIndexData);
+    }
+  );
+  return {
+    ...batch,
+    batchIndex: request.faceIndex,
+    dataValues: hoverIndexData,
+  };
 }
 
 export const terminateHealpixWorker = client.terminate;

--- a/src/lib/grids/healpixWorkerProtocol.ts
+++ b/src/lib/grids/healpixWorkerProtocol.ts
@@ -14,6 +14,7 @@ import type {
 
 export type THealpixBuildRequest = {
   grid: GridOptions;
+  faceIndex: number;
   data: Float32Array;
   cells?: number[];
   attributes: Attributes;
@@ -33,6 +34,6 @@ export type THealpixBatch = { batchIndex: number } & ReturnType<
   ReturnType<typeof buildHealpixTexture>;
 export type THealpixWorkerResponse = TGridGeometryWorkerResponse<
   THealpixWorkerMetadata,
-  THealpixBatch,
-  Float32Array
+  Omit<THealpixBatch, "dataValues">,
+  Float32Array<ArrayBuffer>
 >;

--- a/src/lib/grids/healpixWorkerProtocol.ts
+++ b/src/lib/grids/healpixWorkerProtocol.ts
@@ -1,0 +1,38 @@
+import type { GridOptions } from "healpix-geo";
+import type { Attributes } from "zarrita";
+
+import type { TGridGeometryWorkerResponse } from "./gridGeometryWorkerProtocol.ts";
+import type {
+  buildHealpixGeometry,
+  buildHealpixTexture,
+} from "./healpixCalculations.ts";
+
+import type {
+  TProjectionCenter,
+  TProjectionType,
+} from "@/lib/projection/projectionUtils.ts";
+
+export type THealpixBuildRequest = {
+  grid: GridOptions;
+  data: Float32Array;
+  cells?: number[];
+  attributes: Attributes;
+  missingValue: number;
+  fillValue: number;
+  projectionType: TProjectionType;
+  projectionCenter: TProjectionCenter;
+};
+
+export type THealpixWorkerRequest = THealpixBuildRequest & {
+  requestId: number;
+};
+export type THealpixWorkerMetadata = { totalBatches: number };
+export type THealpixBatch = { batchIndex: number } & ReturnType<
+  typeof buildHealpixGeometry
+> &
+  ReturnType<typeof buildHealpixTexture>;
+export type THealpixWorkerResponse = TGridGeometryWorkerResponse<
+  THealpixWorkerMetadata,
+  THealpixBatch,
+  Float32Array
+>;

--- a/src/lib/shaders/glsl/textureColormap.frag.glsl
+++ b/src/lib/shaders/glsl/textureColormap.frag.glsl
@@ -10,6 +10,9 @@ uniform float posterizeLevels;
 uniform float hideBelowValue;
 uniform float hideAboveValue;
 uniform sampler2D data;
+uniform vec2 dataUvOffset;
+uniform vec2 dataUvScale;
+uniform int clipToDataRect;
 uniform int projectionType;
 uniform float projectionRadius;
 uniform int edgeQuality;
@@ -18,7 +21,15 @@ varying vec2 vUv;
 varying vec2 vProjectedXY;
 
 void main() {
-    float v_value = texture(data, vUv).r;
+    vec2 dataUv = (vUv - dataUvOffset) / dataUvScale;
+    // Only a HEALPix face cropped to its sparse data's bounding box clips here;
+    // a full-face/full-globe texture (the common case) relies on the texture's
+    // own wrap mode instead, e.g. RepeatWrapping across the lon-wrap seam.
+    if (clipToDataRect == 1
+    && (dataUv.x < 0.0 || dataUv.x > 1.0 || dataUv.y < 0.0 || dataUv.y > 1.0)) {
+        discard;
+    }
+    float v_value = texture(data, dataUv).r;
     if ((edgeQuality > 0 && !isInsideProjectionDomain(vProjectedXY, projectionType, projectionRadius))
     || is_nan(v_value) || v_value <= hideBelowValue || v_value >= hideAboveValue) {
         discard;

--- a/src/lib/shaders/gridShaders.ts
+++ b/src/lib/shaders/gridShaders.ts
@@ -89,6 +89,14 @@ export function makeGpuProjectedTextureMaterial(
       hideBelowValue: { value: -1e38 },
       hideAboveValue: { value: 1e38 },
       data: { value: texture },
+      // The full-face UV rectangle the texture actually covers (identity
+      // unless the texture only holds a sub-region, e.g. a regional dataset).
+      dataUvOffset: { value: new THREE.Vector2(0, 0) },
+      dataUvScale: { value: new THREE.Vector2(1, 1) },
+      // Off by default: only a HEALPix face cropped to a sparse data's
+      // bounding box turns this on. Left off elsewhere so a texture's own
+      // wrap mode (e.g. RepeatWrapping across the lon-wrap seam) still works.
+      clipToDataRect: { value: 0 },
       // Projection uniforms
       projectionType: {
         value: PROJECTION_TYPE_BY_MODE[PROJECTION_TYPES.NEARSIDE_PERSPECTIVE],

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -29,9 +29,13 @@ import {
   getGridVariableData,
   terminateGridDataWorker,
 } from "@/lib/grids/gridDataWorkerClient.ts";
-import { HEALPIX_NUMCHUNKS } from "@/lib/grids/healpixCalculations.ts";
 import {
-  buildHealpixGrid,
+  HEALPIX_NUMCHUNKS,
+  getHealpixFaceRange,
+  getHealpixTextureIndex,
+} from "@/lib/grids/healpixCalculations.ts";
+import {
+  buildHealpixFace,
   terminateHealpixWorker,
 } from "@/lib/grids/healpixWorkerClient.ts";
 import type { THealpixBatch } from "@/lib/grids/healpixWorkerProtocol.ts";
@@ -110,9 +114,6 @@ const {
 const { setHoverLookup, clearHoverLookup } =
   useGridHoverLookup(hoveredGeoPoint);
 
-const hoverData = ref<Float32Array | null>(null);
-const hoverCellIndexMap = ref<Map<bigint, number> | null>(null);
-const hoverNside = ref<number | null>(null);
 const selectedDimensionNames = ref<string[]>([]);
 
 const healpixGrid = ref<healpixGeo.Grid | null>(null);
@@ -559,43 +560,61 @@ function updateHealpixBatch(batch: THealpixBatch) {
   updateMeshProjectionUniforms();
 }
 
+// eslint-disable-next-line max-lines-per-function
 async function processHealpixChunks(
   datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
   cells: number[] | undefined,
   grid: healpixGeo.Grid,
-  data: Float32Array
+  indices: (number | zarr.Slice | null)[]
 ) {
   let dataMin = Number.POSITIVE_INFINITY;
   let dataMax = Number.NEGATIVE_INFINITY;
   const histogramSummaries: THistogramSummary[] = [];
   const helper = projectionHelper.value;
-  hoverData.value = await buildHealpixGrid(
-    {
-      grid: {
-        scheme: grid.scheme,
-        level: grid.level,
-        ellipsoid: {
-          // eslint-disable-next-line camelcase
-          semi_major_axis: grid.semiMajorAxis,
-          // eslint-disable-next-line camelcase
-          semi_minor_axis: grid.semiMajorAxis * (1 - grid.flattening),
-        },
+  const options = {
+    grid: {
+      scheme: grid.scheme,
+      level: grid.level,
+      ellipsoid: {
+        // eslint-disable-next-line camelcase
+        semi_major_axis: grid.semiMajorAxis,
+        // eslint-disable-next-line camelcase
+        semi_minor_axis: grid.semiMajorAxis * (1 - grid.flattening),
       },
-      data,
-      cells,
-      attributes: datavar.attrs,
-      ...getHealpixMissingAndFillValues(datavar),
-      projectionType: helper.type,
-      projectionCenter: { lat: helper.center.lat, lon: helper.center.lon },
     },
-    (batch) => {
-      const summary = batch.histogramSummary;
-      histogramSummaries.push(summary);
-      dataMin = dataMin > summary.min ? summary.min : dataMin;
-      dataMax = dataMax < summary.max ? summary.max : dataMax;
-      updateHealpixBatch(batch);
+    attributes: datavar.attrs,
+    ...getHealpixMissingAndFillValues(datavar),
+    projectionType: helper.type,
+    projectionCenter: { lat: helper.center.lat, lon: helper.center.lon },
+  };
+  clearHoverLookup();
+  // Read, transfer and render one face before fetching the next (256 MiB at level 13).
+  for (let faceIndex = 0; faceIndex < HEALPIX_NUMCHUNKS; faceIndex++) {
+    if (disposed) {
+      return;
     }
-  );
+    const range = getHealpixFaceRange(faceIndex, grid.nside, cells);
+    const selection = indices.slice();
+    selection[selection.length - 1] = zarr.slice(range.start, range.end);
+    const data =
+      range.start === range.end
+        ? new Float32Array()
+        : castDataVarToFloat32(await fetchHealpixVariableData(selection));
+    if (disposed) {
+      return;
+    }
+    const batch = await buildHealpixFace({
+      ...options,
+      faceIndex,
+      data,
+      cells: range.cells,
+    });
+    const summary = batch.histogramSummary;
+    histogramSummaries.push(summary);
+    dataMin = dataMin > summary.min ? summary.min : dataMin;
+    dataMax = dataMax < summary.max ? summary.max : dataMax;
+    updateHealpixBatch(batch);
+  }
   return { dataMin, dataMax, histogramSummaries };
 }
 
@@ -610,31 +629,22 @@ function healpixHoverLookup(
     return null;
   }
 
-  if (!hoverData.value) {
-    return null;
-  }
-
   const normalizedLon = ProjectionHelper.normalizeLongitude(lon);
   const coords = new Float64Array([normalizedLon, lat]);
   const pixelIndices = grid.lonLatToHealpix(coords);
   const pixelIndex = pixelIndices[0];
 
-  const dataIndex = hoverCellIndexMap.value
-    ? hoverCellIndexMap.value.get(pixelIndex)
-    : Number(pixelIndex);
-  if (
-    dataIndex === undefined ||
-    dataIndex < 0 ||
-    dataIndex >= hoverData.value.length
-  ) {
-    return {
-      lat,
-      lon: normalizedLon,
-      value: null,
-      status: HOVERED_GRID_POINT_STATUS.MISSING,
-    };
+  const pixel = Number(pixelIndex);
+  const faceSize = grid.nside * grid.nside;
+  const mesh = mainMeshes[Math.floor(pixel / faceSize)];
+  if (!mesh) {
+    return null;
   }
-  const value = hoverData.value[dataIndex];
+  const texture = (mesh.material as THREE.ShaderMaterial).uniforms.data
+    .value as THREE.DataTexture;
+  // Hover reads the same array as the texture, without retaining a second 3 GiB grid.
+  const data = texture.image.data as Float32Array;
+  const value = data[getHealpixTextureIndex(pixel % faceSize, grid.nside)];
   const pixelAngles = grid.healpixToLonLat(pixelIndices);
 
   const isMissing = !Number.isFinite(value) || value === HEALPIX_UNSEEN;
@@ -656,26 +666,11 @@ async function fetchAndRenderData(
   const { dimensionRanges, indices } = await prepareDimensionData(datavar);
 
   const cellCoord = await getCells();
-  hoverNside.value = grid.nside;
-  const data = castDataVarToFloat32(await fetchHealpixVariableData(indices));
-  if (disposed) {
+  const result = await processHealpixChunks(datavar, cellCoord, grid, indices);
+  if (!result) {
     return;
   }
-  const { dataMin, dataMax, histogramSummaries } = await processHealpixChunks(
-    datavar,
-    cellCoord,
-    grid,
-    data
-  );
-  if (cellCoord) {
-    const cellIndexMap = new Map<bigint, number>();
-    for (let index = 0; index < cellCoord.length; index++) {
-      cellIndexMap.set(BigInt(cellCoord[index]), index);
-    }
-    hoverCellIndexMap.value = cellIndexMap;
-  } else {
-    hoverCellIndexMap.value = null;
-  }
+  const { dataMin, dataMax, histogramSummaries } = result;
   setHoverLookup(healpixHoverLookup);
   updateHistogram(histogramSummaries, dataMin, dataMax);
 

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -2,7 +2,7 @@
 import * as healpixGeo from "healpix-geo";
 import { storeToRefs } from "pinia";
 import * as THREE from "three";
-import { onBeforeMount, onBeforeUnmount, ref, watch } from "vue";
+import { onBeforeMount, onBeforeUnmount, ref } from "vue";
 import * as zarr from "zarrita";
 
 import {
@@ -17,8 +17,6 @@ import { useStreamlineLayer } from "./composables/useStreamlineLayer.ts";
 import { buildDimensionRangesAndIndices } from "@/lib/data/dimensionHandling.ts";
 import {
   castDataVarToFloat32,
-  decodeVariableDataAndGetBounds,
-  decodeVariableDataInPlace,
   getFillValue,
   getMissingValue,
 } from "@/lib/data/variableDecoding.ts";
@@ -27,7 +25,16 @@ import {
   resolveVectorVariablePair,
 } from "@/lib/data/vectorField.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
-import { terminateGridDataWorker } from "@/lib/grids/gridDataWorkerClient.ts";
+import {
+  getGridVariableData,
+  terminateGridDataWorker,
+} from "@/lib/grids/gridDataWorkerClient.ts";
+import { HEALPIX_NUMCHUNKS } from "@/lib/grids/healpixCalculations.ts";
+import {
+  buildHealpixGrid,
+  terminateHealpixWorker,
+} from "@/lib/grids/healpixWorkerClient.ts";
+import type { THealpixBatch } from "@/lib/grids/healpixWorkerProtocol.ts";
 import {
   createTriangleWrapProjectionGeometry,
   createWrappedProjectionMesh,
@@ -38,7 +45,6 @@ import { ProjectionHelper } from "@/lib/projection/projectionUtils.ts";
 import {
   getColormapScaleOffset,
   makeGpuProjectedTextureMaterial,
-  updateProjectionUniforms,
 } from "@/lib/shaders/gridShaders.ts";
 import type { TDimensionRange, TSources } from "@/lib/types/GlobeTypes.ts";
 import { useUrlParameterStore } from "@/store/paramStore.ts";
@@ -47,18 +53,14 @@ import {
   useGlobeControlStore,
 } from "@/store/store.ts";
 import { useLog } from "@/ui/common/useLog.ts";
-import {
-  HISTOGRAM_SUMMARY_BINS,
-  buildHistogramSummary,
-  type THistogramSummary,
-} from "@/utils/histogram.ts";
+import type { THistogramSummary } from "@/utils/histogram.ts";
 
 const props = defineProps<{
   datasources?: TSources;
 }>();
 
 // By convention, HEALPIX uses -1.6375e+30 to mark invalid or unseen pixels.
-const HEALPIX_UNSEEN = -1.6375e30;
+const HEALPIX_UNSEEN = new Float32Array([-1.6375e30])[0];
 
 function getHealpixMissingAndFillValues(
   datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>
@@ -125,7 +127,7 @@ type TStreamlineContext = {
 let lastStreamlineContext: TStreamlineContext | undefined;
 let streamlineRequestRevision = 0;
 
-const HEALPIX_NUMCHUNKS = 12;
+let disposed = false;
 
 let mainMeshes: Array<THREE.Mesh | undefined> = new Array(HEALPIX_NUMCHUNKS);
 
@@ -159,7 +161,6 @@ const { datasourceUpdate } = useGridDataLoader({
   getDataVar,
   fetchAndRenderData,
   clearHoverLookup,
-  prepareDatasource: fetchGrid,
   updateLandSeaMask,
   updateColormap: () => updateColormap(mainMeshes),
   refreshStreamlines: async (reuseCached) => {
@@ -171,35 +172,6 @@ const { datasourceUpdate } = useGridDataLoader({
     }
   },
 });
-
-function fetchGrid() {
-  const grid = unpackGrid();
-  const textureGrid = grid.replace({ level: 0, scheme: "nested" });
-
-  const gridStep = 64 + 1;
-  try {
-    for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ipix++) {
-      const { geometry } = makeHealpixGeometry(
-        textureGrid,
-        BigInt(ipix),
-        gridStep,
-        projectionHelper.value
-      );
-      const mesh = mainMeshes[ipix];
-      if (!mesh) {
-        continue;
-      }
-      mesh.geometry.dispose();
-      setupProjectionGeometryWrap(geometry);
-      mesh.geometry = geometry;
-    }
-    // Update projection uniforms after geometry change
-    updateMeshProjectionUniforms();
-    redraw();
-  } catch (error) {
-    logError(error, "Could not fetch grid");
-  }
-}
 
 function coerceInteger(value: unknown): number | null {
   const cast = typeof value === "number" ? value : Number(value);
@@ -346,15 +318,10 @@ async function getCells() {
   }
 
   try {
-    const rawCells = (
-      await ZarrDataManager.getVariableData(
-        ZarrDataManager.getDatasetSource(
-          props.datasources!,
-          varnameSelector.value
-        ),
-        ZarrDataManager.resolveVariablePath(varnameSelector.value, cellCoord)
-      )
-    ).data as ArrayLike<number | bigint>;
+    const rawCells = await fetchHealpixVariableData(
+      [],
+      ZarrDataManager.resolveVariablePath(varnameSelector.value, cellCoord)
+    );
 
     return Array.from(rawCells, (cell) => Number(cell));
   } catch {
@@ -362,199 +329,29 @@ async function getCells() {
   }
 }
 
-function getHealpixChunkRange(
-  ipix: number,
-  numChunks: number,
-  grid: healpixGeo.Grid
+function fetchHealpixVariableData(
+  selection: (number | zarr.Slice | null)[],
+  variable = varnameSelector.value
 ) {
-  const nside = grid.nside;
-
-  const chunksize = (12 * nside * nside) / numChunks;
-  const pixelStart = ipix * chunksize;
-  const pixelEnd = (ipix + 1) * chunksize;
-
-  return { chunksize, pixelStart, pixelEnd };
-}
-
-async function fillGlobalHealpixChunkData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  localDimensionIndices: (number | zarr.Slice | null)[],
-  pixelStart: number,
-  pixelEnd: number,
-  dataSlice: Float32Array
-) {
-  localDimensionIndices[localDimensionIndices.length - 1] = zarr.slice(
-    pixelStart,
-    pixelEnd
-  );
-  const data = (
-    await ZarrDataManager.getVariableDataFromArray(
-      datavar,
-      localDimensionIndices
-    )
-  ).data as Float32Array;
-
-  dataSlice.set(data);
-}
-
-async function fillLimitedAreaHealpixChunkData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  cellCoord: number[],
-  localDimensionIndices: (number | zarr.Slice | null)[],
-  pixelStart: number,
-  pixelEnd: number,
-  dataSlice: Float32Array
-) {
-  // Limited-area data case: need to map cellCoord to global positions
-  dataSlice.fill(NaN);
-
-  // Find which indices in cellCoord fall within this chunk's range
-  const relevantIndices: number[] = [];
-  const localPositions: number[] = [];
-
-  for (let i = 0; i < cellCoord.length; i++) {
-    const globalPixel = cellCoord[i];
-    if (globalPixel >= pixelStart && globalPixel < pixelEnd) {
-      relevantIndices.push(i); // Index in the data array
-      localPositions.push(globalPixel - pixelStart); // Position in chunk
-    }
-  }
-
-  // Only fetch data if this chunk has any relevant cells
-  if (relevantIndices.length === 0) {
-    return;
-  }
-
-  // Check if indices are contiguous for optimization
-  const start = relevantIndices[0];
-  const end = relevantIndices[relevantIndices.length - 1] + 1;
-  localDimensionIndices[localDimensionIndices.length - 1] = zarr.slice(
-    start,
-    end
-  );
-  const data = (
-    await ZarrDataManager.getVariableDataFromArray(
-      datavar,
-      localDimensionIndices
-    )
-  ).data as Float32Array;
-  const isContiguous =
-    relevantIndices.length > 1 &&
-    relevantIndices[relevantIndices.length - 1] - relevantIndices[0] ===
-      relevantIndices.length - 1;
-
-  if (isContiguous) {
-    // Contiguous: use slice for efficient fetching
-    for (let i = 0; i < relevantIndices.length; i++) {
-      dataSlice[localPositions[i]] = data[i];
-    }
-  } else {
-    // Non-contiguous: fetch the entire range and skip what we don't need
-    for (let i = 0; i < relevantIndices.length; i++) {
-      const dataIdx = relevantIndices[i] - start;
-      dataSlice[localPositions[i]] = data[dataIdx];
-    }
-  }
-}
-
-async function fillHealpixChunkData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  cellCoord: number[] | undefined,
-  localDimensionIndices: (number | zarr.Slice | null)[],
-  pixelStart: number,
-  pixelEnd: number,
-  dataSlice: Float32Array
-) {
-  if (cellCoord === undefined) {
-    await fillGlobalHealpixChunkData(
-      datavar,
-      localDimensionIndices,
-      pixelStart,
-      pixelEnd,
-      dataSlice
-    );
-  } else {
-    await fillLimitedAreaHealpixChunkData(
-      datavar,
-      cellCoord,
-      localDimensionIndices,
-      pixelStart,
-      pixelEnd,
-      dataSlice
-    );
-  }
-}
-
-async function getHealpixData(
-  datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  cellCoord: number[] | undefined, // Optional - undefined for global data
-  ipix: number,
-  numChunks: number,
-  grid: healpixGeo.Grid,
-  dimensionIndices: (number | zarr.Slice | null)[]
-) {
-  const localDimensionIndices = dimensionIndices.slice();
-  const { chunksize, pixelStart, pixelEnd } = getHealpixChunkRange(
-    ipix,
-    numChunks,
-    grid
-  );
-  const dataSlice = new Float32Array(chunksize);
-
-  await fillHealpixChunkData(
-    datavar,
-    cellCoord,
-    localDimensionIndices,
-    pixelStart,
-    pixelEnd,
-    dataSlice
-  );
-
-  const { missingValue, fillValue } = getHealpixMissingAndFillValues(datavar);
-  const { min, max } = decodeVariableDataAndGetBounds(
-    datavar,
-    dataSlice,
-    missingValue,
-    fillValue
-  );
-
-  // Filter out missing and fill values before building histogram
-  return {
-    texture: data2texture(dataSlice, {}),
-    histogramSummary: buildHistogramSummary(
-      dataSlice,
-      min,
-      max,
-      HISTOGRAM_SUMMARY_BINS,
-      fillValue,
-      missingValue
+  return getGridVariableData({
+    source: ZarrDataManager.getDatasetSource(
+      props.datasources!,
+      varnameSelector.value
     ),
-    min,
-    max,
-    missingValue,
-    fillValue,
-  };
-}
-
-function distanceSquared(
-  x1: number,
-  y1: number,
-  z1: number,
-  x2: number,
-  y2: number,
-  z2: number
-): number {
-  return (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1);
+    variable,
+    format: props.datasources!.zarr_format,
+    selection,
+  });
 }
 
 function createGeometry(
   positionValues: Float32Array,
   uv: Float32Array,
   latLonValues: Float32Array,
-  indices: number[]
+  indices: Uint32Array
 ) {
   const geometry = new THREE.InstancedBufferGeometry();
-  geometry.setIndex(indices);
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
   geometry.setAttribute(
     "position",
     new THREE.Float32BufferAttribute(positionValues, 3)
@@ -566,143 +363,6 @@ function createGeometry(
     new THREE.Float32BufferAttribute(latLonValues, 2)
   );
   return createTriangleWrapProjectionGeometry(geometry);
-}
-
-function generateHealpixIndices(positionValues: Float32Array, steps: number) {
-  const indices = [];
-  for (let i = 0; i < steps - 1; ++i) {
-    for (let j = 0; j < steps - 1; ++j) {
-      const a = i * steps + (j + 1);
-      const b = i * steps + j;
-      const c = (i + 1) * steps + j;
-      const d = (i + 1) * steps + (j + 1);
-      const dac2 = distanceSquared(
-        positionValues[3 * a + 0],
-        positionValues[3 * a + 1],
-        positionValues[3 * a + 2],
-        positionValues[3 * c + 0],
-        positionValues[3 * c + 1],
-        positionValues[3 * c + 2]
-      );
-      const dbd2 = distanceSquared(
-        positionValues[3 * b + 0],
-        positionValues[3 * b + 1],
-        positionValues[3 * b + 2],
-        positionValues[3 * d + 0],
-        positionValues[3 * d + 1],
-        positionValues[3 * d + 2]
-      );
-      if (dac2 < dbd2) {
-        indices.push(a, c, d);
-        indices.push(b, c, a);
-      } else {
-        indices.push(a, b, d);
-        indices.push(b, c, d);
-      }
-    }
-  }
-  return indices;
-}
-
-function makeHealpixGeometry(
-  grid: healpixGeo.Grid,
-  ipix: bigint,
-  steps: number,
-  helper: ProjectionHelper
-) {
-  const vertexCount = steps * steps;
-  const positionValues = new Float32Array(vertexCount * 3);
-  const uv = new Float32Array(vertexCount * 2);
-  const latitudes = new Float32Array(vertexCount);
-  const longitudes = new Float32Array(vertexCount);
-  const latLonValues = new Float32Array(vertexCount * 2);
-  let vertexIndex = 0;
-
-  const coords = grid.vertices(BigInt(ipix), steps);
-  for (let index = 0; index < Math.floor(coords.length / 2); ++index) {
-    let indexLon = 2 * index;
-    let indexLat = 2 * index + 1;
-    const lat = coords[indexLat];
-    const lon = coords[indexLon];
-
-    const u = Math.floor(index / steps) / (steps - 1);
-    const v = (index % steps) / (steps - 1);
-
-    latitudes[vertexIndex] = lat;
-    longitudes[vertexIndex] = lon;
-
-    const positionOffset = vertexIndex * 3;
-    helper.projectLatLonToArrays(
-      lat,
-      lon,
-      positionValues,
-      positionOffset,
-      latLonValues,
-      vertexIndex * 2
-    );
-
-    const uvIndex = vertexIndex * 2;
-    uv[uvIndex] = u;
-    uv[uvIndex + 1] = v;
-
-    vertexIndex++;
-  }
-
-  const indices = generateHealpixIndices(positionValues, steps);
-  const geometry = createGeometry(positionValues, uv, latLonValues, indices);
-  return { geometry, latitudes, longitudes };
-}
-
-function getUnshuffleIndex(
-  size: number,
-  unshuffleIndex: { [key: number]: Float32Array }
-): Float32Array {
-  if (unshuffleIndex[size] === undefined) {
-    const grid = unpackGrid();
-
-    const temp = grid.bitCombineTable(size);
-
-    // this will fail for chunks with a size greater than 16777215, which is about a base cell at level 11-12
-    const table = new Float32Array(temp.length);
-    temp.forEach((value, index) => {
-      table[index] = Number(value);
-    });
-
-    unshuffleIndex[size] = table;
-  }
-  return unshuffleIndex[size];
-}
-
-function unshuffleMortonArray(
-  arr: Float32Array,
-  unshuffleIndex: { [key: number]: Float32Array }
-): Float32Array {
-  const out = arr.slice(); // makes a copy
-  const size = Math.floor(Math.sqrt(arr.length));
-  const uidx = getUnshuffleIndex(size, unshuffleIndex);
-  for (let i = 0; i < out.length; ++i) {
-    out[i] = arr[uidx[i]];
-  }
-  return out;
-}
-
-function data2texture(
-  arr: Float32Array,
-  unshuffleIndex: { [key: number]: Float32Array }
-) {
-  const size = Math.floor(Math.sqrt(arr.length));
-  arr = castDataVarToFloat32(arr);
-  const mortonArr = unshuffleMortonArray(arr, unshuffleIndex);
-  const texture = new THREE.DataTexture(
-    mortonArr,
-    size,
-    size,
-    THREE.RedFormat,
-    THREE.FloatType,
-    THREE.UVMapping
-  );
-  texture.needsUpdate = true;
-  return texture;
 }
 
 async function prepareDimensionData(
@@ -849,56 +509,93 @@ async function getDimensionValues(
   return dimValues;
 }
 
+function updateHealpixBatch(batch: THealpixBatch) {
+  const geometry = createGeometry(
+    batch.positionValues,
+    batch.uv,
+    batch.latLonValues,
+    batch.indices
+  );
+  let mesh = mainMeshes[batch.batchIndex];
+  if (mesh) {
+    mesh.geometry.dispose();
+    setupProjectionGeometryWrap(geometry);
+    mesh.geometry = geometry;
+  } else {
+    const { addOffset, scaleFactor } = getColormapScaleOffset(
+      store.selection?.low as number,
+      store.selection?.high as number,
+      invertColormap.value
+    );
+    const material = makeGpuProjectedTextureMaterial(
+      new THREE.Texture(),
+      colormap.value,
+      addOffset,
+      scaleFactor
+    );
+    material.uniforms.useTriangleWrapCull.value = 1;
+    mesh = createWrappedProjectionMesh(
+      geometry,
+      material,
+      projectionHelper.value.type
+    );
+    mesh.frustumCulled = false;
+    mainMeshes[batch.batchIndex] = mesh;
+    getScene()?.add(mesh);
+  }
+  const material = mesh.material as THREE.ShaderMaterial;
+  material.uniforms.data.value.dispose();
+  const size = Math.sqrt(batch.dataValues.length);
+  const texture = new THREE.DataTexture(
+    batch.dataValues,
+    size,
+    size,
+    THREE.RedFormat,
+    THREE.FloatType,
+    THREE.UVMapping
+  );
+  texture.needsUpdate = true;
+  material.uniforms.data.value = texture;
+  updateMeshProjectionUniforms();
+}
+
 async function processHealpixChunks(
   datavar: zarr.Array<zarr.DataType, zarr.AsyncReadable>,
-  cellCoord: number[] | undefined,
+  cells: number[] | undefined,
   grid: healpixGeo.Grid,
-  indices: (number | zarr.Slice | null)[]
-): Promise<{
-  dataMin: number;
-  dataMax: number;
-  histogramSummaries: THistogramSummary[];
-}> {
+  data: Float32Array
+) {
   let dataMin = Number.POSITIVE_INFINITY;
   let dataMax = Number.NEGATIVE_INFINITY;
   const histogramSummaries: THistogramSummary[] = [];
-
-  await Promise.all(
-    [...Array(HEALPIX_NUMCHUNKS).keys()].map(async (ipix) => {
-      const texData = await getHealpixData(
-        datavar,
-        cellCoord,
-        ipix,
-        HEALPIX_NUMCHUNKS,
-        grid,
-        indices
-      );
-      if (texData === undefined) {
-        const mesh = mainMeshes[ipix];
-        if (!mesh) {
-          return;
-        }
-        const material = mesh.material as THREE.ShaderMaterial;
-        material.uniforms.data.value.dispose();
-        return;
-      }
-
-      histogramSummaries.push(texData.histogramSummary);
-      dataMin = dataMin > texData.min ? texData.min : dataMin;
-      dataMax = dataMax < texData.max ? texData.max : dataMax;
-
-      const mesh = mainMeshes[ipix];
-      if (!mesh) {
-        return;
-      }
-      const material = mesh.material as THREE.ShaderMaterial;
-      material.uniforms.data.value.dispose();
-      material.uniforms.data.value = texData.texture;
-
-      redraw();
-    })
+  const helper = projectionHelper.value;
+  hoverData.value = await buildHealpixGrid(
+    {
+      grid: {
+        scheme: grid.scheme,
+        level: grid.level,
+        ellipsoid: {
+          // eslint-disable-next-line camelcase
+          semi_major_axis: grid.semiMajorAxis,
+          // eslint-disable-next-line camelcase
+          semi_minor_axis: grid.semiMajorAxis * (1 - grid.flattening),
+        },
+      },
+      data,
+      cells,
+      attributes: datavar.attrs,
+      ...getHealpixMissingAndFillValues(datavar),
+      projectionType: helper.type,
+      projectionCenter: { lat: helper.center.lat, lon: helper.center.lon },
+    },
+    (batch) => {
+      const summary = batch.histogramSummary;
+      histogramSummaries.push(summary);
+      dataMin = dataMin > summary.min ? summary.min : dataMin;
+      dataMax = dataMax < summary.max ? summary.max : dataMax;
+      updateHealpixBatch(batch);
+    }
   );
-
   return { dataMin, dataMax, histogramSummaries };
 }
 
@@ -960,15 +657,15 @@ async function fetchAndRenderData(
 
   const cellCoord = await getCells();
   hoverNside.value = grid.nside;
-  hoverData.value = castDataVarToFloat32(
-    (await ZarrDataManager.getVariableDataFromArray(datavar, indices)).data
-  );
-  const { missingValue, fillValue } = getHealpixMissingAndFillValues(datavar);
-  decodeVariableDataInPlace(
-    hoverData.value,
-    datavar.attrs,
-    missingValue,
-    fillValue
+  const data = castDataVarToFloat32(await fetchHealpixVariableData(indices));
+  if (disposed) {
+    return;
+  }
+  const { dataMin, dataMax, histogramSummaries } = await processHealpixChunks(
+    datavar,
+    cellCoord,
+    grid,
+    data
   );
   if (cellCoord) {
     const cellIndexMap = new Map<bigint, number>();
@@ -980,13 +677,6 @@ async function fetchAndRenderData(
     hoverCellIndexMap.value = null;
   }
   setHoverLookup(healpixHoverLookup);
-  const { dataMin, dataMax, histogramSummaries } = await processHealpixChunks(
-    datavar,
-    cellCoord,
-    grid,
-    indices
-  );
-
   updateHistogram(histogramSummaries, dataMin, dataMax);
 
   lastStreamlineContext = { indices, grid, cellCoord };
@@ -1005,64 +695,20 @@ async function fetchAndRenderData(
   void updateStreamlines(lastStreamlineContext);
 }
 
-watch(healpixGrid, async () => {
-  for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ++ipix) {
-    const mesh = mainMeshes[ipix];
-    if (mesh) {
-      getScene()!.add(mesh);
-    }
-  }
-});
-
 onBeforeMount(async () => {
-  const low = store.selection?.low as number;
-  const high = store.selection?.high as number;
-  const { addOffset, scaleFactor } = getColormapScaleOffset(
-    low,
-    high,
-    invertColormap.value
-  );
-
   const grid = await getHealpixGridParameters();
-  healpixGrid.value = grid;
-
-  const textureGrid = grid.replace({ level: 0 });
-
-  const gridStep = 64 + 1;
-  for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ++ipix) {
-    // Use GPU-projected material for instant projection center changes
-    const material = makeGpuProjectedTextureMaterial(
-      new THREE.Texture(),
-      colormap.value,
-      addOffset,
-      scaleFactor
-    );
-    material.uniforms.useTriangleWrapCull.value = 1;
-    // Set initial projection uniforms
-    const helper = projectionHelper.value;
-    updateProjectionUniforms(material, helper);
-
-    const { geometry } = makeHealpixGeometry(
-      textureGrid,
-      BigInt(ipix),
-      gridStep,
-      projectionHelper.value
-    );
-    const mesh = createWrappedProjectionMesh(
-      geometry,
-      material,
-      projectionHelper.value.type
-    );
-    mainMeshes[ipix] = mesh;
-    // Disable frustum culling - GPU projection changes actual positions
-    mesh.frustumCulled = false;
+  if (disposed) {
+    return;
   }
+  healpixGrid.value = grid;
   await datasourceUpdate();
   gridPrepared.value = true;
 });
 
 onBeforeUnmount(() => {
+  disposed = true;
   streamlineRequestRevision++;
+  terminateHealpixWorker();
   terminateGridDataWorker();
   for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ++ipix) {
     const mesh = mainMeshes[ipix];

--- a/src/ui/grids/Healpix.vue
+++ b/src/ui/grids/Healpix.vue
@@ -31,8 +31,9 @@ import {
 } from "@/lib/grids/gridDataWorkerClient.ts";
 import {
   HEALPIX_NUMCHUNKS,
+  decodeHealpixFaceXY,
   getHealpixFaceRange,
-  getHealpixTextureIndex,
+  type THealpixDataRect,
 } from "@/lib/grids/healpixCalculations.ts";
 import {
   buildHealpixFace,
@@ -510,7 +511,56 @@ async function getDimensionValues(
   return dimValues;
 }
 
+function disposeHealpixMesh(batchIndex: number) {
+  const mesh = mainMeshes[batchIndex];
+  if (!mesh) {
+    return;
+  }
+  mesh.geometry.dispose();
+  const mat = mesh.material as THREE.ShaderMaterial;
+  if (mat) {
+    if (mat.uniforms?.data?.value?.dispose) {
+      mat.uniforms.data.value.dispose();
+    }
+    mat.dispose();
+  }
+  getScene()?.remove(mesh);
+  mainMeshes[batchIndex] = undefined;
+}
+
+function createHealpixMesh(
+  batchIndex: number,
+  geometry: THREE.InstancedBufferGeometry
+) {
+  const { addOffset, scaleFactor } = getColormapScaleOffset(
+    store.selection?.low as number,
+    store.selection?.high as number,
+    invertColormap.value
+  );
+  const material = makeGpuProjectedTextureMaterial(
+    new THREE.Texture(),
+    colormap.value,
+    addOffset,
+    scaleFactor
+  );
+  material.uniforms.useTriangleWrapCull.value = 1;
+  const mesh = createWrappedProjectionMesh(
+    geometry,
+    material,
+    projectionHelper.value.type
+  );
+  mesh.frustumCulled = false;
+  mainMeshes[batchIndex] = mesh;
+  getScene()?.add(mesh);
+  return mesh;
+}
+
 function updateHealpixBatch(batch: THealpixBatch) {
+  if (batch.width === 0 || batch.height === 0) {
+    // No cells of a regional/sparse dataset fall in this face.
+    disposeHealpixMesh(batch.batchIndex);
+    return;
+  }
   const geometry = createGeometry(
     batch.positionValues,
     batch.uv,
@@ -523,40 +573,30 @@ function updateHealpixBatch(batch: THealpixBatch) {
     setupProjectionGeometryWrap(geometry);
     mesh.geometry = geometry;
   } else {
-    const { addOffset, scaleFactor } = getColormapScaleOffset(
-      store.selection?.low as number,
-      store.selection?.high as number,
-      invertColormap.value
-    );
-    const material = makeGpuProjectedTextureMaterial(
-      new THREE.Texture(),
-      colormap.value,
-      addOffset,
-      scaleFactor
-    );
-    material.uniforms.useTriangleWrapCull.value = 1;
-    mesh = createWrappedProjectionMesh(
-      geometry,
-      material,
-      projectionHelper.value.type
-    );
-    mesh.frustumCulled = false;
-    mainMeshes[batch.batchIndex] = mesh;
-    getScene()?.add(mesh);
+    mesh = createHealpixMesh(batch.batchIndex, geometry);
   }
+  mesh.userData.dataRect = batch.dataRect;
   const material = mesh.material as THREE.ShaderMaterial;
   material.uniforms.data.value.dispose();
-  const size = Math.sqrt(batch.dataValues.length);
   const texture = new THREE.DataTexture(
     batch.dataValues,
-    size,
-    size,
+    batch.width,
+    batch.height,
     THREE.RedFormat,
     THREE.FloatType,
     THREE.UVMapping
   );
   texture.needsUpdate = true;
   material.uniforms.data.value = texture;
+  material.uniforms.dataUvOffset.value.set(batch.dataRect.u, batch.dataRect.v);
+  material.uniforms.dataUvScale.value.set(
+    batch.dataRect.width,
+    batch.dataRect.height
+  );
+  // Only crop to the rect when it's a genuine sub-region of the face (a
+  // regional/sparse dataset); a full face has nothing to discard around.
+  material.uniforms.clipToDataRect.value =
+    batch.dataRect.width < 1 || batch.dataRect.height < 1 ? 1 : 0;
   updateMeshProjectionUniforms();
 }
 
@@ -644,7 +684,17 @@ function healpixHoverLookup(
     .value as THREE.DataTexture;
   // Hover reads the same array as the texture, without retaining a second 3 GiB grid.
   const data = texture.image.data as Float32Array;
-  const value = data[getHealpixTextureIndex(pixel % faceSize, grid.nside)];
+  const dataRect = mesh.userData.dataRect as THealpixDataRect;
+  const { x, y } = decodeHealpixFaceXY(pixel % faceSize);
+  const localX = x - Math.round(dataRect.u * grid.nside);
+  const localY = y - Math.round(dataRect.v * grid.nside);
+  const value =
+    localX < 0 ||
+    localX >= texture.image.width ||
+    localY < 0 ||
+    localY >= texture.image.height
+      ? NaN
+      : data[localY * texture.image.width + localX];
   const pixelAngles = grid.healpixToLonLat(pixelIndices);
 
   const isMissing = !Number.isFinite(value) || value === HEALPIX_UNSEEN;
@@ -706,20 +756,7 @@ onBeforeUnmount(() => {
   terminateHealpixWorker();
   terminateGridDataWorker();
   for (let ipix = 0; ipix < HEALPIX_NUMCHUNKS; ++ipix) {
-    const mesh = mainMeshes[ipix];
-    if (!mesh) {
-      continue;
-    }
-    mesh.geometry.dispose();
-    const mat = mesh.material as THREE.ShaderMaterial;
-    if (mat) {
-      if (mat.uniforms?.data?.value?.dispose) {
-        mat.uniforms.data.value.dispose();
-      }
-      mat.dispose();
-    }
-    getScene()?.remove(mesh);
-    mainMeshes[ipix] = undefined;
+    disposeHealpixMesh(ipix);
   }
 });
 

--- a/src/ui/grids/composables/useGridScene.ts
+++ b/src/ui/grids/composables/useGridScene.ts
@@ -1006,11 +1006,7 @@ export function useGridScene(options: UseGridSceneOptions) {
       controlsUpdated,
       userInteractionActive
     );
-    if (
-      !userInteractionActive &&
-      !store.isRotating &&
-      animationCallbacks.size === 0
-    ) {
+    if (!userInteractionActive && !store.isRotating) {
       if (controlsUpdated) {
         // Controls are still moving (damping draining) – reset idle counter.
         idleFrameCount = 0;
@@ -1021,16 +1017,18 @@ export function useGridScene(options: UseGridSceneOptions) {
         cameraState.encodeCameraToURL(cam, projectionHelper.value.isFlat);
       }
       if (idleFrameCount >= IDLE_FRAMES_BEFORE_STOP) {
-        // Damping is fully drained – safe to stop the loop.
-        idleFrameCount = 0;
+        // Save the settled camera even when layer animations keep running.
         setMotionState(false);
-        if (cam) {
+        if (cam && idleFrameCount === IDLE_FRAMES_BEFORE_STOP) {
           cameraState.debouncedEncodeCameraToURL(
             cam,
             projectionHelper.value.isFlat
           );
         }
-        return;
+        if (animationCallbacks.size === 0) {
+          idleFrameCount = 0;
+          return;
+        }
       }
     } else {
       idleFrameCount = 0;

--- a/src/utils/histogram.ts
+++ b/src/utils/histogram.ts
@@ -27,27 +27,18 @@ export function buildHistogramSummary(
   fillValue?: number,
   missingValue?: number
 ): THistogramSummary {
-  const data = filterInvalidData(rawData, missingValue, fillValue);
   const bins = new Uint32Array(numBins);
-
-  if (!isFinite(min) || !isFinite(max) || data.length === 0) {
+  if (!isFinite(min) || !isFinite(max)) {
     return { bins, min, max };
   }
-
   const range = max - min;
-  // Handle degenerate case where all values are at a single point (min === max).
-  // In this case, avoid division by zero by placing all entries into the first bin.
-  if (range === 0) {
-    for (let i = 0; i < data.length; i++) {
-      bins[0]++;
-    }
-    return { bins, min, max };
-  }
   const binSize = range / numBins;
-
-  for (let i = 0; i < data.length; i++) {
-    const value = data[i];
-    let binIndex = Math.floor((value - min) / binSize);
+  for (let i = 0; i < rawData.length; i++) {
+    const value = rawData[i];
+    if (!isFinite(value) || value === missingValue || value === fillValue) {
+      continue;
+    }
+    let binIndex = range === 0 ? 0 : Math.floor((value - min) / binSize);
     if (binIndex < 0) {
       binIndex = 0;
     }
@@ -56,30 +47,7 @@ export function buildHistogramSummary(
     }
     bins[binIndex]++;
   }
-
   return { bins, min, max };
-}
-
-function filterInvalidData(
-  data: ArrayLike<number>,
-  missingValue?: number,
-  fillValue?: number
-) {
-  const validData: number[] = [];
-  for (let i = 0; i < data.length; i++) {
-    const value = data[i];
-    if (!isFinite(value)) {
-      continue;
-    }
-    if (missingValue !== undefined && value === missingValue) {
-      continue;
-    }
-    if (fillValue !== undefined && value === fillValue) {
-      continue;
-    }
-    validData.push(value);
-  }
-  return validData;
 }
 
 function countBins(bins: Uint32Array): number {

--- a/tests/unit/lib/grids/healpixCalculations.test.ts
+++ b/tests/unit/lib/grids/healpixCalculations.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from "vitest";
+
+import {
+  buildHealpixTexture,
+  getHealpixFaceRange,
+  getHealpixTextureIndex,
+} from "@/lib/grids/healpixCalculations.ts";
+import { buildHistogramSummary } from "@/utils/histogram.ts";
+
+it("splits a level-13 grid into contiguous 256 MiB float32 faces", () => {
+  const nside = 8192;
+  for (let face = 0; face < 12; face++) {
+    const range = getHealpixFaceRange(face, nside);
+    expect(range.start).toBe(face * nside ** 2);
+    expect(range.end).toBe((face + 1) * nside ** 2);
+    expect((range.end - range.start) * 4).toBe(256 * 1024 ** 2);
+  }
+});
+
+it("reads shuffled sparse cells from the correct face and skips empty faces", () => {
+  const cells = [191, 4, 0];
+  expect(getHealpixFaceRange(0, 4, cells)).toEqual({
+    start: 1,
+    end: 3,
+    cells: [4, 0],
+  });
+  expect(getHealpixFaceRange(1, 4, cells)).toEqual({
+    start: 0,
+    end: 0,
+    cells: [],
+  });
+  expect(getHealpixFaceRange(11, 4, cells)).toEqual({
+    start: 0,
+    end: 1,
+    cells: [191],
+  });
+});
+
+it("uses texture storage for exact nested-pixel hover values", () => {
+  const values = Float32Array.from({ length: 16 }, (_, pixel) => pixel);
+  const texture = buildHealpixTexture(values, 11, 4).dataValues;
+  expect([...texture]).toEqual([
+    0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15,
+  ]);
+  for (let pixel = 0; pixel < 16; pixel++) {
+    expect(texture[getHealpixTextureIndex(pixel, 4)]).toBe(pixel);
+  }
+  expect(getHealpixTextureIndex(2 ** 24, 8192)).toBe(4096);
+  expect(getHealpixTextureIndex(8192 ** 2 - 1, 8192)).toBe(8192 ** 2 - 1);
+});
+
+it("builds histograms without copying values and preserves invalid-value handling", () => {
+  const values = new Float32Array([NaN, Infinity, -999, -888, -1, 0, 1, 2, 3]);
+  expect([...buildHistogramSummary(values, 0, 2, 2, -999, -888).bins]).toEqual([
+    2, 3,
+  ]);
+  expect([...buildHistogramSummary([5, NaN, 5], 5, 5, 2).bins]).toEqual([2, 0]);
+  expect([...buildHistogramSummary([NaN], NaN, NaN, 2).bins]).toEqual([0, 0]);
+  expect(values[0]).toBeNaN();
+  expect(values[2]).toBe(-999);
+});

--- a/tests/unit/ui/grids/composables/useGridScene.test.ts
+++ b/tests/unit/ui/grids/composables/useGridScene.test.ts
@@ -1,0 +1,105 @@
+import * as THREE from "three";
+import { afterEach, expect, it, vi } from "vitest";
+import { computed, effectScope, ref } from "vue";
+
+const { mounted, unmounted } = vi.hoisted(() => ({
+  mounted: [] as (() => void)[],
+  unmounted: [] as (() => void)[],
+}));
+
+vi.mock("vue", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue")>()),
+  onMounted: (callback: () => void) => mounted.push(callback),
+  onBeforeUnmount: (callback: () => void) => unmounted.push(callback),
+}));
+
+vi.mock("@vueuse/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@vueuse/core")>()),
+  useEventListener: vi.fn(),
+  useResizeObserver: vi.fn(),
+}));
+
+vi.mock("three", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("three")>()),
+  WebGLRenderer: class {
+    domElement = Object.assign(new EventTarget(), {
+      ownerDocument: new EventTarget(),
+      style: { touchAction: "" },
+      getRootNode() {
+        return this.ownerDocument;
+      },
+    });
+    render() {}
+    dispose() {}
+  },
+}));
+
+vi.mock("@/ui/grids/composables/useGridSnapshot.ts", () => ({
+  useGridSnapshot: () => ({ makeSnapshot: vi.fn() }),
+}));
+
+vi.stubGlobal("localStorage", { getItem: () => null });
+
+const { createPinia, setActivePinia } = await import("pinia");
+const { useUrlParameterStore } = await import("@/store/paramStore.ts");
+const { ProjectionHelper, PROJECTION_TYPES } =
+  await import("@/lib/projection/projectionUtils.ts");
+const { EARTH_RADIUS_METERS, useGridCameraState } =
+  await import("@/ui/grids/composables/useGridCameraState.ts");
+const { useGridScene } = await import("@/ui/grids/composables/useGridScene.ts");
+
+afterEach(() => {
+  unmounted.splice(0).forEach((callback) => callback());
+  mounted.length = 0;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+it.each([4, 16])(
+  "saves the closest altitude while layer animation continues (%i ms frames)",
+  async (frameDuration) => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { innerWidth: 800, innerHeight: 600 });
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(performance.now()), frameDuration)
+    );
+    vi.stubGlobal("cancelAnimationFrame", clearTimeout);
+    setActivePinia(createPinia());
+    const scope = effectScope();
+    const cameraState = useGridCameraState();
+    const grid = scope.run(() =>
+      useGridScene({
+        projectionHelper: computed(
+          () =>
+            new ProjectionHelper(PROJECTION_TYPES.NEARSIDE_PERSPECTIVE, {
+              lat: 0,
+              lon: 0,
+            })
+        ),
+        projectionCenter: ref({ lat: 0, lon: 0 }),
+        controlPanelVisible: ref(false),
+        cameraState,
+      })
+    )!;
+    mounted.forEach((callback) => callback());
+    const camera = grid.getCamera() as THREE.PerspectiveCamera;
+    const previousAltitude = useUrlParameterStore().paramCameraAlt;
+    camera.position.setLength(0.5);
+    const animateLayer = vi.fn();
+    const stopAnimation = grid.registerAnimationCallback(animateLayer);
+
+    try {
+      await vi.advanceTimersByTimeAsync(1200);
+      expect(useUrlParameterStore().paramCameraAlt).not.toBe(previousAltitude);
+      expect(useUrlParameterStore().paramCameraAlt).toBe(
+        String(Math.round(0.12 * EARTH_RADIUS_METERS))
+      );
+      const frameCount = animateLayer.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(100);
+      expect(animateLayer.mock.calls.length).toBeGreaterThan(frameCount);
+    } finally {
+      stopAnimation();
+      scope.stop();
+    }
+  }
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,17 @@
 import { fileURLToPath, URL } from "url";
 
 import vue from "@vitejs/plugin-vue";
-import glsl from "vite-plugin-glsl";
 import { defineConfig } from "vite";
+import glsl from "vite-plugin-glsl";
 import wasm from "vite-plugin-wasm";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue(), glsl(), wasm()],
+  worker: {
+    format: "es",
+    plugins: () => [wasm()],
+  },
   build: {
     sourcemap: true,
   },


### PR DESCRIPTION
Add HEALPix workers and support large grids (#197) in Chrome

Move HEALPix data loading and geometry, texture, and histogram calculations into web workers using the existing shared worker infrastructure.
- Process one face at a time—256 MiB at level 13—to avoid allocating the entire 3 GiB timestep.
- Transfer buffers without copying and reuse texture data for hover lookup.
- Replace the large Morton lookup table with a compact per-axis lookup and remove intermediate histogram copies.
- Preserve limited-area data and missing-value handling.
- Register the worker’s message handler before loading WASM, preventing lost startup requests.
- Remove duplicate data reads and add regression checks.

(yes, it's vibe-coded)

To my surprise, the one riomar dataset with shifted pixels creates a correct result now...by accident...  

@keewis since you mentioned that the dataset did not work for you on the finest resolution because of your machine, could you check again?
https://feat-webworker-healpix.gridlook.pages.dev/#https://pangeo-eosc-minioapi.vm.fedcloud.eu/afouilloux-riomar/small_hp_pyramid.zarr::varname=0/temp::px=0::py=0::alt=4247741::dimIndices_time_counter=0::dimIndices_s_rho=0::lat=46.9682::lon=-3.0384